### PR TITLE
Use `completing-read` instead of `magit-completing-read`

### DIFF
--- a/vdiff-magit.el
+++ b/vdiff-magit.el
@@ -125,8 +125,8 @@ conflicts, including those already resolved by Git, use
          (unmerged (magit-unmerged-files)))
      (unless unmerged
        (user-error "There are no unresolved conflicts"))
-     (list (magit-completing-read "Resolve file" unmerged nil t nil nil
-                                  (car (member current unmerged))))))
+     (list (completing-read "Resolve file" unmerged nil t nil nil
+                            (car (member current unmerged))))))
   (if vdiff-magit-use-ediff-for-merges
       (magit-ediff-resolve file)
     (vdiff-merge-conflict file)))
@@ -136,9 +136,9 @@ conflicts, including those already resolved by Git, use
   "Stage and unstage changes to FILE using vdiff.
 FILE has to be relative to the top directory of the repository."
   (interactive
-   (list (magit-completing-read "Selectively stage file" nil
-                                (magit-tracked-files) nil nil nil
-                                (magit-current-file))))
+   (list (completing-read "Selectively stage file" nil
+                          (magit-tracked-files) nil nil nil
+                          (magit-current-file))))
   (magit-with-toplevel
     (let* ((buf-a (or (magit-get-revision-buffer "HEAD" file)
                       (magit-find-file-noselect "HEAD" file)))


### PR DESCRIPTION
This PR fixes the following issue for me: when I run `vdiff-magit-stage`, I get the following error:

```

Debugger entered--Lisp error: (invalid-function (".gitignore" ".travis.yml" "Makefile" "README.md" "evil-goggles.el" "test/elpa.el" "test/evil-goggles-test.el" "test/make-checkdoc.el" "test/make-compile.el" "test/make-evil-test.el" "test/make-test.el" "test/make-update.el"))
  (".gitignore" ".travis.yml" "Makefile" "README.md" "evil-goggles.el" "test/elpa.el" "test/evil-goggles-test.el" "test/make-checkdoc.el" "test/make-compile.el" "test/make-evil-test.el" "test/make-test.el" "test/make-update.el")("README.md")
  cl-remove(nil ("README.md") :if-not (".gitignore" ".travis.yml" "Makefile" "README.md" "evil-goggles.el" "test/elpa.el" "test/evil-goggles-test.el" "test/make-checkdoc.el" "test/make-compile.el" "test/make-evil-test.el" "test/make-test.el" "test/make-update.el"))
  apply(cl-remove nil ("README.md") :if-not (".gitignore" ".travis.yml" "Makefile" "README.md" "evil-goggles.el" "test/elpa.el" "test/evil-goggles-test.el" "test/make-checkdoc.el" "test/make-compile.el" "test/make-evil-test.el" "test/make-test.el" "test/make-update.el") nil)
  cl-remove-if-not((".gitignore" ".travis.yml" "Makefile" "README.md" "evil-goggles.el" "test/elpa.el" "test/evil-goggles-test.el" "test/make-checkdoc.el" "test/make-compile.el" "test/make-evil-test.el" "test/make-test.el" "test/make-update.el") ("README.md"))
  ivy--reset-state(#s(ivy-state :prompt "Selectively stage file: " :collection ("README.md") :predicate (".gitignore" ".travis.yml" "Makefile" "README.md" "evil-goggles.el" "test/elpa.el" "test/evil-goggles-test.el" "test/make-checkdoc.el" "test/make-compile.el" "test/make-evil-test.el" "test/make-test.el" "test/make-update.el") :require-match nil :initial-input nil :history nil :preselect "README.md" :keymap nil :update-fn nil :sort t :frame #<frame emacs 0x102812c30> :window #<window 3 on README.md> :buffer #<buffer README.md> :text nil :action (1 ("o" identity "default") ("i" #f(compiled-function (x) #<bytecode 0x44207095>) "insert") ("w" #f(compiled-function (x) #<bytecode 0x442070a5>) "copy")) :unwind nil :re-builder nil :matcher nil :dynamic-collection nil :display-transformer-fn nil :directory "/Users/edkolev/dev/evil-goggles/" :caller vdiff-magit-stage :current nil :def "README.md"))
  ivy-read("Selectively stage file: " ("README.md") :predicate (".gitignore" ".travis.yml" "Makefile" "README.md" "evil-goggles.el" "test/elpa.el" "test/evil-goggles-test.el" "test/make-checkdoc.el" "test/make-compile.el" "test/make-evil-test.el" "test/make-test.el" "test/make-update.el") :require-match nil :initial-input nil :preselect "README.md" :def "README.md" :history nil :keymap nil :sort t :dynamic-collection nil :caller nil)
  ivy-completing-read("Selectively stage file: " ("README.md") (".gitignore" ".travis.yml" "Makefile" "README.md" "evil-goggles.el" "test/elpa.el" "test/evil-goggles-test.el" "test/make-checkdoc.el" "test/make-compile.el" "test/make-evil-test.el" "test/make-test.el" "test/make-update.el") nil nil nil "README.md" nil)
  completing-read("Selectively stage file: " ("README.md") (".gitignore" ".travis.yml" "Makefile" "README.md" "evil-goggles.el" "test/elpa.el" "test/evil-goggles-test.el" "test/make-checkdoc.el" "test/make-compile.el" "test/make-evil-test.el" "test/make-test.el" "test/make-update.el") nil nil nil "README.md")
  magit-builtin-completing-read("Selectively stage file: " ("README.md") (".gitignore" ".travis.yml" "Makefile" "README.md" "evil-goggles.el" "test/elpa.el" "test/evil-goggles-test.el" "test/make-checkdoc.el" "test/make-compile.el" "test/make-evil-test.el" "test/make-test.el" "test/make-update.el") nil nil nil "README.md")
  magit-completing-read("Selectively stage file" nil (".gitignore" ".travis.yml" "Makefile" "README.md" "evil-goggles.el" "test/elpa.el" "test/evil-goggles-test.el" "test/make-checkdoc.el" "test/make-compile.el" "test/make-evil-test.el" "test/make-test.el" "test/make-update.el") nil nil nil "README.md")
  (list (magit-completing-read "Selectively stage file" nil (magit-tracked-files) nil nil nil (magit-current-file)))
  call-interactively(vdiff-magit-stage record nil)
  command-execute(vdiff-magit-stage record)
  #f(compiled-function (cmd) #<bytecode 0x44107281>)("vdiff-magit-stage")
  ivy-call()
  ivy-read("M-x " ("toggle-debug-on-error" "vdiff-magit-popup" "vdiff-files3" "desktop-save-mode" "desktop-remove" "diff-hl-mode" "evil-goggles-mode" "counsel-load-theme" "checkdoc" "counsel-set-variable" "checkdoc-defun" "package-lint-current-buffer" "org-mode" "text-mode" "counsel-find-library" "counsel-faces" "git-link-homepage" "untabify" "emacs-lisp-mode" "json-pretty-print-buffer" "byte-compile-file" "ert" "emacs-version" "revert-buffer" "magit-find-file" "align-regexp" "which-key-mode" "git-link" "vdiff-quit" "markdown-mode" "js-mode" "perl-mode" "electric-pair-local-mode" "desktop-clear" "load-theme" "flyspell-buffer" "yas-expand" "elp-results" "vdiff-buffers" "make-directory" "ivy-resume" "flyspell-mode" "evil-window-right" "update-file-autoloads" "mu4e" "widen" "swiper" "sql-mode" "describe-key" "profiler-start" "outshine-cycle-buffer" "magit-list-repositories" "try" "compile" "js2-mode" "vdiff-mode" "company-mode" "flycheck-mode" "undo-tree-undo" "restclient-mode" "package-refresh-contents" "occur" "regex-tool" "org-version" "nameless-mode" "counsel-yank-pop" "org-bullets-mode" "outline-minor-mode" "use-package-report" "counsel-switch-to-shell-buffer" "align" "ispell" "ivy-mode" "shell-pop" "minions-mode" "ido-find-file" "git-link-commit" "recentf-cleanup" "narrow-to-region" "visual-line-mode" "counsel-find-file" "list-faces-display" "diff-hl-revert-hunk" "ert-run-tests-interactively" "sh-mode" "butterfly" "html-mode" "eldoc-mode" "shell-mode" "counsel-git" "beacon-blink" "hs-minor-mode" "yas-minor-mode" "customize-group" "org-indent-mode" "pixel-scroll-mode" "evgeni-intercept-mode" "org-narrow-to-subtree" "vdiff-refine-all-hunks" "vdiff-magit-show-unstaged" "which-key-show-major-mode" "diff" "eshell" "quickurl" "speedbar" "sql-mysql" "cperl-mode" "artist-mode" "beacon-mode" "outline-mode" "rainbow-mode" "counsel-imenu" "replace-string" "package-install" "magit-diff-popup" "set-input-method" "vc-refresh-state" "project-find-file" "electric-pair-mode" "moody-replace-vc-mode" "xref-find-definitions" "counsel-describe-function" "projectile-switch-project" "tramp-cleanup-all-buffers" "dired-sidebar-toggle-sidebar" "magit" "shell" "ivy-avy" "newline" "vc-diff" "ansi-term" "eros-mode" "java-mode" "company-go" "counsel-ag" "linum-mode" "swiper-all" "abbrev-mode" "auto-insert" "evil-buffer" "ledger-mode" "org-capture" "clojure-mode" "desktop-read" "flymake-mode" "hl-todo-mode" "ivy-alt-done" "magit-status" "origami-mode" "evil-org-mode" "auto-fill-mode" "markdown-cycle" "diff-split-hunk" "javascript-mode" "org-cycle-level" "show-paren-mode" "which-func-mode" "line-number-mode" "smartparens-mode" "vdiff-hydra/body" "diff-hl-mark-hunk" "json-pretty-print" "magit-file-delete" "mu4e-conversation" "check-declare-file" "column-number-mode" "package-autoremove" "avy-goto-char-timer" "byte-recompile-file" "global-diff-hl-mode" "global-hl-todo-mode" "list-colors-display" "transient-mark-mode" "electric-indent-mode" "evil-visualstar-mode" "fit-window-to-buffer" "projectile-find-file" "paradox-list-packages" "minions-minor-modes-menu" "paradox-upgrade-packages" "company-filter-candidates" "haskell-process-load-file" "markdown-narrow-to-subtree" "projectile-skel-dir-locals" "git-commit-insert-issue-ask-issues" "zygospore-toggle-delete-other-windows" "pwd" "ediff" "imenu" "woman" "c-mode" "vc-dir" "go-mode" "ibuffer" "how-many" "find-file" "mail-mode" "yaml-mode" "browse-url" "counsel-rg" "dired-undo" "elisp-mode" "evil-rot13" "find-dired" "iedit-mode" "org-agenda" "eval-buffer" "eval-region" "fill-region" "kill-buffer" "other-frame" "desktop-save" "evgeni-shell" "evil-version" "align-current" "describe-mode" "hl-todo-occur" "magit-version" "outshine-menu" "semantic-mode" "shell-command" "evil-lion-left" "fill-paragraph" "package-delete" "read-only-mode" "regexp-builder" "reverse-region" "avy-copy-region" "command-history" "dockerfile-mode" "flyspell-region" "git-timemachine" "isearch-forward" "projectile-grep" "projectile-mode" "try-and-refresh" "yas-global-mode" "browse-url-emacs" "fundamental-mode" "magit-file-popup" "org-global-cycle" "report-emacs-bug" "beginning-of-line" "counsel-descbinds" "counsel-file-jump" "describe-function" "describe-variable" "evil-normal-state" "forward-paragraph" "ispell-minor-mode" "ivy-switch-buffer" "magit-file-rename" "text-scale-adjust" "use-hard-newlines" "outline-hide-other" "pp-eval-expression" "vdiff-current-file" "back-to-indentation" "describe-minor-mode" "toggle-input-method" "yas-describe-tables" "company-manual-begin" "counsel-colors-emacs" "narrow-reindent-mode" "size-indication-mode" "checkdoc-ispell-start" "diff-buffer-with-file" "flyspell-correct-word" "linum-relative-toggle" "lisp-interaction-mode" "sp-forward-slurp-sexp" "counsel-evil-registers" "customize-create-theme" "dired-mark-executables" "evil-multiedit-restore" "yas-visit-snippet-file" "elp-instrument-function" "projectile-test-project" "vdiff-magit-show-staged" "animate-birthday-present" "evil-paste-from-register" "fill-region-as-paragraph" "indent-according-to-mode" "outshine-narrow-to-subtree" "projectile-compile-project" "projectile-edit-dir-locals" "wgrep-change-to-wgrep-mode" "which-key-setup-minibuffer" "all-the-icons-install-fonts" "desktop-save-in-desktop-dir" "magit-diff-buffer-file-popup" "moody-replace-mode-line-buffer-identification" "cd" "5x5" "arp" "dbx" "dig" "erc" "eww" "ftp" "gdb" "irc" "jdb" "man" "mpc" "pdb" "rsh" "sdb" "xdb" "calc" "dirs" "ffap" "gnus" "grep" "help" "ielm" "info" "life" "mail" "mpuz" "ping" "pong" "smex" "talk" "term" "undo" "yank" "zone" "chmod" "debug" "diary" "dired" "edirs" "godoc" "hanoi" "hayoo" "lgrep" "mkdir" "rcirc" "rgrep" "rmail" "route" "snake" "spook" "tumme" "whois" "cookie" "doctor" "dunnet" "ediff3" "edirs3" "epatch" "finger" "getenv" "gomoku" "guiler" "hoogle" "ignore" "locate" "perldb" "proced" "repeat" "rlogin" "rzgrep" "setenv" "sql-ms" "tabify" "telnet" "tetris" "thumbs" "zrgrep" "Info-up" "apropos" "battery" "bs-show" "bubbles" "c-guess" "erc-tls" "evil-ex" "fortune" "gud-gdb" "m2-mode" "m4-mode" "netstat" "pr-help" "ps-mode" "run-dig" "run-lua" "sql-db2" "suggest" "unrmail" "up-list" "vc-pull" "vc-push" "version" "webjump" "2C-split" "Info-toc" "TeX-mode" "ada-mode" "appt-add" "asm-mode" "awk-mode" "bat-mode" "blackbox" "c++-mode" "calendar" "css-mode" "cua-mode" "dcl-mode" "decipher" "dns-mode" "ebuffers" "evil-ret" "eww-mode" "f90-mode" "ffap-bug" "find-tag" "gfm-mode" "holidays" "idl-mode" "ido-mode" "ifconfig" "ivy-call" "ivy-done" "ivy-help" "iwconfig" "lua-mode" "markdown" "mh-nmail" "mh-rmail" "mh-smail" "mml-menu" "mml-mode" "msb-mode" "nslookup" "org-copy" "org-goto" "org-info" "org-lint" "org-sort" "org-todo" "org-yank" "php-mode" "recenter" "remember" "rst-mode" "run-lisp" "ses-mode" "show-all" "srt-mode" "tar-mode" "tcl-mode" "tex-mode" "url-mail" "vc-ediff" "vc-merge" "where-is" "xml-mode" "yank-pop" "5x5-crack" "Info-edit" "Info-exit" "Info-help" "Info-last" "Info-menu" "Info-mode" "Info-next" "Info-prev" "ad-update" "benchmark" "calc-undo" "conf-mode" "copy-file" "copyright" "customize" "diff-mode" "diff-undo" "dired-why" "down-list" "ebuffers3" "eregistry" "erevision" "evil-copy" "evil-edit" "evil-fill" "evil-join" "evil-line" "evil-make" "evil-mode" "evil-move" "evil-quit" "evil-read" "evil-save" "evil-yank" "ffap-menu" "ffap-next" "find-grep" "full-calc" "goto-char" "goto-line" "grep-find" "grep-mode" "handwrite" "help-mode" "help-quit" "hexl-mode" "hide-body" "icon-mode" "ido-dired" "image-bob" "image-bol" "image-eob" "image-eol" "indent-to" "ivy-occur" "join-line" "kill-grep" "kill-line" "kill-sexp" "kill-word" "left-char" "left-word" "lisp-mode" "list-tags" "lm-verify" "load-file" "magit-log" "magit-tag" "make-face" "mark-page" "mark-sexp" "mark-word" "mule-diag" "new-frame" "next-file" "next-line" "nxml-mode" "objc-mode" "open-line" "org-cycle" "org-occur" "org-timer" "pcomplete" "pike-mode" "prog-mode" "recompile" "rjsx-mode" "ruby-mode" "rust-mode" "scroll-up" "scss-mode" "sgml-mode" "snmp-mode" "solitaire" "sql-solid" "swiper-mc" "texi2info" "todo-mode" "todo-show" "toml-mode" "top-level" "tramp-bug" "undefined" "undo-only" "unix-sync" "vc-ignore" "vc-revert" "vc-update" "vera-mode" "vhdl-mode" "view-file" "view-mode" "view-todo" "what-line" "what-page" "yas-about" "yas/about" "zone-mode" "2C-command" "Custom-set" "Info-index" "Info-split" "LaTeX-mode" "ad-recover" "ada-header" "antlr-mode" "array-mode" "avy-resume" "browse-web" "calculator" "comint-bol" "comint-run" "counsel-cl" "counsel-el" "counsel-pt" "cvs-status" "cvs-update" "cwarn-mode" "diary-mode" "dired-diff" "dired-jump" "dired-mark" "dsssl-mode" "ediff-quit" "elide-head" "elint-file" "erc-select" "eval-defun" "evil-a-tag" "evil-org-<" "evil-org->" "evil-write" "forms-mode" "gnus-slave" "hanoi-unix" "hide-entry" "hide-other" "image-mode" "image-save" "iso-german" "keep-lines" "kill-emacs" "kkc-region" "latex-mode" "lpr-buffer" "lpr-region" "magit-diff" "magit-init" "magit-mode" "magit-pull" "magit-push" "make-frame" "man-follow" "mark-defun" "media-type" "mh-version" "mhtml-mode" "mixal-mode" "mouse-kill" "next-error" "next-match" "nginx-mode" "nroff-mode" "occur-mode" "occur-next" "occur-prev" "org-attach" "org-metaup" "org-refile" "org-reload" "org-return" "org-reveal" "orgtbl-ret" "orgtbl-tab" "pr-ps-name" "ps-despool" "quick-calc" "raise-sexp" "re-builder" "read-color" "right-char" "right-word" "rmail-bury" "rmail-mail" "rmail-mime" "rmail-mode" "rmail-quit" "ruler-mode" "run-octave" "run-prolog" "run-python" "run-scheme" "show-entry" "sieve-mode" "sort-lines" "sort-pages" "split-line" "sql-ingres" "sql-linter" "sql-oracle" "sql-sqlite" "sql-sybase" "swiper-avy" "time-stamp" "traceroute" "type-break" "ucs-insert" "vc-hg-pull" "vc-hg-push" "viper-mode" "write-file" "yas/expand" "Custom-help" "Custom-mode" "Custom-save" "Helper-help" "Info-search" "Info-tagify" "about-emacs" "ad-activate" "ad-unadvise" "allout-mode" "avy-isearch" "bibtex-mode" "buffer-menu" "bury-buffer" "c-add-style" "c-set-style" "calc-keypad" "center-line" "comint-mode" "comment-box" "company-css" "counsel-M-x" "counsel-ack" "counsel-clj" "counsel-fzf" "counsel-rpm" "counsel-tmm" "count-words" "custom-mode" "cvs-examine" "debug-watch" "delete-char" "delete-file" "delete-pair" "delphi-mode" "diff-backup" "disassemble" "doctex-mode" "double-mode" "ediff-files" "ediff-merge" "edirs-merge" "elint-defun" "end-of-line" "epl-refresh" "erc-add-pal" "eshell-mode" "evgeni-mu4e" "evgeni-star" "evil-a-WORD" "evil-a-word" "evil-append" "evil-change" "evil-delete" "evil-indent" "evil-insert" "evil-lookup" "evil-repeat" "evil-upcase" "first-error" "flush-lines" "focus-frame" "follow-mode" "fringe-mode" "gitlab-kill" "gitlab-mode" "help-follow" "hide-leaves" "http-header" "http-method" "ido-pop-dir" "iimage-mode" "image-dired" "indent-sexp" "info-finder" "insert-char" "insert-file" "insert-pair" "intero-mode" "invert-face" "iso-iso2tex" "iso-spanish" "iso-tex2iso" "ispell-word" "ivy-partial" "ivy-recentf" "js-jsx-mode" "kill-region" "list-timers" "lm-synopsis" "lower-frame" "magit-apply" "magit-blame" "magit-clean" "magit-clone" "magit-fetch" "magit-merge" "magit-reset" "magit-stage" "magit-stash" "markdown-do" "master-mode" "message-tab" "mml-preview" "modify-face" "multi-occur" "nato-region" "next-buffer" "normal-mode" "octave-mode" "org-columns" "org-content" "org-id-copy" "org-id-goto" "org-publish" "org-shiftup" "org-switchb" "orgtbl-mode" "pascal-mode" "pr-txt-mode" "pr-txt-name" "prolog-mode" "push-button" "python-mode" "quit-window" "raise-frame" "refill-mode" "reftex-mode" "rename-file" "reveal-mode" "rmail-input" "rmail-reply" "rmail-widen" "run-at-time" "run-haskell" "save-buffer" "scheme-mode" "scroll-down" "scroll-left" "serial-term" "server-edit" "server-mode" "simula-mode" "slitex-mode" "smerge-mode" "smerge-next" "smerge-prev" "smerge-swap" "smex-update" "snmpv2-mode" "sort-fields" "sql-connect" "sql-vertica" "tags-search" "tmm-menubar" "untrace-all" "upcase-char" "upcase-dwim" "upcase-word" "vc-annotate" "vc-dir-mark" "vc-dir-menu" "vc-dir-mode" "vc-git-grep" "vc-register" "vdiff-files" "view-buffer" "what-domain" "windmove-up" "winner-mode" "winner-redo" "winner-undo" "zap-to-char" "Info-history" "Info-summary" "align-entire" "autoarg-mode" "avy-pop-mark" "bookmark-set" "bs-customize" "c-set-offset" "check-parens" "clone-buffer" "comment-dwim" "comment-kill" "comment-line" "company-bbdb" "company-capf" "company-diag" "company-nxml" "complete-tag" "compose-mail" "counsel-dpkg" "counsel-grep" "counsel-jedi" "counsel-mode" "crm-complete" "cvs-checkout" "cvs-quickdir" "delete-frame" "dired-unmark" "dired-upcase" "display-time" "do-auto-save" "ebnf-despool" "edebug-defun" "ediff-backup" "ediff-files3" "edit-abbrevs" "edit-picture" "edmacro-mode" "eieio-browse" "emacs-uptime" "emerge-files" "enable-theme" "end-of-defun" "epa-key-mode" "epa-mark-key" "erase-buffer" "erc-add-fool" "erc-log-mode" "evil-a-curly" "evil-a-paren" "evil-ex-join" "evil-ex-sort" "evil-ex-yank" "evil-org-top" "evil-replace" "find-library" "fortran-mode" "forward-char" "forward-line" "forward-list" "forward-page" "forward-sexp" "forward-word" "generic-mode" "glasses-mode" "gnus-plugged" "goto-address" "haskell-menu" "haskell-mode" "help-go-back" "hi-lock-mode" "hide-subtree" "hindent-mode" "hl-line-mode" "hl-todo-next" "holiday-list" "hydra-repeat" "ibuffer-jump" "ibuffer-mode" "ibuffer-yank" "idlwave-mode" "ido-complete" "ido-push-dir" "image-rotate" "inferior-tcl" "info-apropos" "isearch-exit" "iso-gtex2iso" "iso-iso2gtex" "iso-iso2sgml" "iso-sgml2iso" "ivy-pop-view" "js2-jsx-mode" "kill-comment" "list-abbrevs" "list-buffers" "load-library" "lunar-phases" "magit-branch" "magit-cherry" "magit-commit" "magit-rebase" "magit-reflog" "magit-revert" "manual-entry" "mercury-mode" "message-info" "message-mail" "message-mode" "message-news" "message-send" "mml-validate" "morse-region" "move-text-up" "not-modified" "ns-find-file" "opascal-mode" "org-add-note" "org-clock-in" "org-deadline" "org-goto-ret" "org-metadown" "org-metaleft" "org-org-menu" "org-overview" "org-priority" "org-schedule" "org-set-tags" "org-shifttab" "org-src-mode" "org-tbl-menu" "orgtbl-error" "other-window" "picture-mode" "plstore-mode" "pop-tag-mark" "pr-customize" "pr-interface" "print-buffer" "print-region" "quickurl-ask" "recentf-mode" "recover-file" "rmail-resend" "rmail-search" "rot13-region" "scroll-right" "select-frame" "server-start" "set-variable" "shackle-mode" "show-subtree" "sieve-manage" "sieve-upload" "smerge-ediff" "snippet-mode" "sort-columns" "special-mode" "sql-informix" "sql-postgres" "strokes-help" "strokes-mode" "subword-mode" "swiper-multi" "t-mouse-mode" "table-insert" "tags-apropos" "talk-connect" "texinfo-mode" "tildify-mode" "timeclock-in" "tooltip-mode" "url-view-url" "vc-git-stash" "vc-mode-line" "vc-print-log" "vc-root-diff" "verilog-mode" "view-lossage" "visible-mode" "write-region" "Info-top-node" "Info-validate" "ad-deactivate" "ad-update-all" "ada-find-file" "appt-activate" "apropos-value" "autoconf-mode" "avy-copy-line" "avy-goto-char" "avy-goto-line" "avy-move-line" "backward-char" "backward-list" "backward-page" "backward-sexp" "backward-word" "bookmark-jump" "bookmark-load" "bookmark-save" "browse-url-w3" "bs-cycle-next" "calc-dispatch" "calc-embedded" "calendar-exit" "calendar-mode" "center-region" "clojurec-mode" "company-abort" "company-clang" "company-cmake" "company-eclim" "company-elisp" "company-etags" "company-files" "company-gtags" "company-tempo" "company-xcode" "compile-defun" "conf-ppd-mode" "counsel-irony" "count-matches" "cperl-perldoc" "cycle-spacing" "decipher-mode" "delete-region" "delete-window" "denato-region" "describe-char" "describe-face" "describe-font" "dired-do-copy" "dired-do-load" "dired-summary" "dired-tree-up" "dirtrack-mode" "disable-theme" "doc-view-mode" "downcase-dwim" "downcase-word" "easy-menu-add" "ebnf-eps-file" "ediff-buffers" "ediff-profile" "ediff-suspend" "ediff-version" "eieio-version" "end-kbd-macro" "end-of-buffer" "enriched-mode" "epa-info-mode" "epa-list-keys" "epa-mail-mode" "epa-mail-sign" "epa-sign-file" "epatch-buffer" "erc-fill-mode" "erc-menu-mode" "erc-ring-mode" "evgeni-g-star" "evgeni-source" "evil-a-symbol" "evil-an-angle" "evil-downcase" "evil-exchange" "evil-quit-all" "eww-open-file" "expand-abbrev" "ffap-at-mouse" "ffap-bindings" "ffap-next-url" "find-function" "find-variable" "flyspell-word" "font-show-log" "footnote-mode" "gfm-view-mode" "ghc-core-mode" "git-commit-cc" "github-issues" "gitlab-browse" "gnus-agentize" "gnus-msg-mail" "hanoi-unix-64" "haskell-hayoo" "haskell-rgrep" "help-for-help" "hippie-expand" "http-relation" "iconify-frame" "idlwave-shell" "ido-toggle-vc" "indent-region" "inferior-lisp" "insert-buffer" "isearch-abort" "isearch-occur" "iso-iso2duden" "ispell-buffer" "ispell-region" "iswitchb-mode" "ivy-kill-line" "ivy-kill-word" "ivy-next-line" "ivy-push-view" "ivy-yank-char" "ivy-yank-word" "keyboard-quit" "kill-sentence" "less-css-mode" "list-fontsets" "list-holidays" "list-packages" "lm-report-bug" "local-set-key" "log-edit-done" "log-edit-menu" "log-edit-mode" "log-view-mode" "lpr-customize" "magit-am-skip" "magit-discard" "magit-log-all" "magit-refresh" "magit-reverse" "magit-unstage" "magit-wip-log" "mail-complete" "makefile-mode" "markdown-open" "menu-bar-mode" "menu-bar-open" "menu-set-font" "message-reply" "metafont-mode" "metapost-mode" "midnight-mode" "modula-2-mode" "mwheel-scroll" "ns-next-frame" "ns-prev-frame" "nslookup-host" "org-clock-out" "org-customize" "org-do-demote" "org-emphasize" "org-goto-left" "org-goto-quit" "org-kill-line" "org-metaright" "org-next-item" "org-next-link" "org-open-line" "org-shiftdown" "org-shiftleft" "org-sort-list" "org-table-sum" "org-tags-view" "org-todo-list" "outline-cycle" "outshine-navi" "outshine-sort" "outshine-todo" "pop-to-buffer" "pr-ps-utility" "pr-txt-buffer" "pr-txt-region" "previous-line" "projectile-ag" "projectile-vc" "query-replace" "quickurl-list" "quoted-insert" "recode-region" "rename-buffer" "rmail-expunge" "rmail-forward" "rmail-summary" "savehist-mode" "savehist-save" "set-face-font" "show-branches" "show-children" "shrink-window" "smerge-refine" "smex-where-is" "smiley-buffer" "smiley-region" "sql-interbase" "studlify-word" "suspend-emacs" "suspend-frame" "table-capture" "table-justify" "table-release" "tildify-space" "timeclock-out" "tool-bar-mode" "tramp-version" "unbury-buffer" "unfocus-frame" "upcase-region" "vc-create-tag" "vc-dir-ignore" "vc-dir-search" "vc-dir-unmark" "vdiff-refresh" "view-register" "widget-browse" "windmove-down" "windmove-left" "x-select-font" "xref--mouse-2" "2C-two-columns" "Custom-newline" "Custom-no-edit" "Info-directory" "Info-edit-mode" "Info-goto-node" "Info-mode-menu" "Info-scroll-up" "Info-undefined" "ad-activate-on" "ad-clear-cache" "ad-recover-all" "append-to-file" "auto-save-mode" "avy-linum-mode" "bookmark-write" "browse-url-cci" "browse-url-kde" "browse-url-man" "c-guess-buffer" "c-guess-region" "c-macro-expand" "canlock-verify" "cfengine2-mode" "cfengine3-mode" "checkdoc-start" "clipboard-yank" "clojure-thread" "clojure-unwind" "comment-indent" "comment-region" "company-abbrev" "company-ignore" "company-ispell" "compose-region" "conf-toml-mode" "conf-unix-mode" "copy-directory" "copy-to-buffer" "counsel-locate" "counsel-recoll" "counsel-wmctrl" "cpp-parse-edit" "customize-face" "customize-mode" "dabbrev-expand" "debug-on-entry" "define-abbrevs" "describe-theme" "desktop-revert" "diff-file-kill" "diff-file-next" "diff-file-prev" "diff-hunk-kill" "diff-hunk-next" "diff-hunk-prev" "diff-kill-junk" "diff-mode-menu" "diff-test-hunk" "digit-argument" "dired-at-point" "dired-do-chgrp" "dired-do-chmod" "dired-do-chown" "dired-do-print" "dired-do-touch" "dired-downcase" "dired-hide-all" "display-buffer" "ebnf-customize" "ebnf-pop-style" "ediff-buffers3" "ediff-re-merge" "ediff-recenter" "ediff-revision" "edir-revisions" "edit-bookmarks" "edit-kbd-macro" "edit-tab-stops" "emerge-buffers" "enable-command" "enlarge-window" "epa-unmark-key" "erc-delete-pal" "erc-track-mode" "eshell-command" "eudc-get-email" "eudc-get-phone" "eudc-load-eudc" "eval-last-sexp" "evgeni-toggles" "evil-a-bracket" "evil-ex-delete" "evil-ex-global" "evil-ex-normal" "evil-ex-repeat" "evil-ex-resize" "evil-find-char" "evil-goto-char" "evil-goto-line" "evil-goto-mark" "evil-inner-tag" "evil-jump-item" "evil-lion-mode" "evil-next-line" "evil-open-fold" "evil-paste-pop" "evil-scroll-up" "evil-window-up" "evil-write-all" "evil-yank-line" "ffap-gnus-menu" "ffap-gnus-next" "ffap-literally" "ffap-read-only" "font-lock-mode" "forward-button" "forward-symbol" "git-commit-ack" "gitlab-version" "global-set-key" "gnus-copy-file" "gnus-jog-cache" "gnus-no-server" "gnus-unplugged" "go-eldoc-setup" "gpm-mouse-mode" "haskell-hoogle" "help-mode-menu" "hexl-find-file" "hexlify-buffer" "hide-sublevels" "hydra-ivy/body" "ibuffer-update" "icomplete-mode" "ido-edit-input" "ido-everywhere" "ido-next-match" "ido-prev-match" "ido-write-file" "imenu-anywhere" "indent-pp-sexp" "indent-rigidly" "info-emacs-bug" "insert-abbrevs" "isearch-cancel" "ispell-message" "ivy-mouse-done" "ivy-occur-mode" "js2-minor-mode" "just-one-space" "kill-paragraph" "kill-rectangle" "kill-ring-save" "ld-script-mode" "list-bookmarks" "list-directory" "list-processes" "list-registers" "locate-library" "macrostep-mode" "magit-am-abort" "magit-am-popup" "magit-checkout" "magit-log-head" "magit-log-mode" "magit-push-tag" "magit-run-gitk" "magit-snapshot" "make-face-bold" "mark-paragraph" "message-bounce" "message-resend" "mh-folder-mode" "mouse-set-font" "mouse-set-mark" "move-text-down" "move-to-column" "narrow-to-page" "ns-drag-n-drop" "ns-insert-file" "open-rectangle" "org-clock-goto" "org-ctrl-c-ret" "org-do-promote" "org-goto-right" "org-inc-effort" "org-next-block" "org-set-effort" "org-shiftright" "org-show-entry" "org-store-link" "org-time-stamp" "org-timer-item" "org-up-element" "orgstruct-mode" "outline-demote" "outshine-imenu" "outshine-timer" "overwrite-mode" "password-reset" "pcomplete-help" "pcomplete-list" "plain-TeX-mode" "plain-tex-mode" "pr-toggle-line" "pr-toggle-lock" "pr-toggle-mode" "previous-error" "read-kbd-macro" "recursive-edit" "redraw-display" "remember-notes" "replace-regexp" "rmail-continue" "rst-minor-mode" "run-with-timer" "scroll-up-line" "search-forward" "send-invisible" "set-file-modes" "set-frame-font" "set-frame-name" "signal-process" "smerge-resolve" "sp-cheat-sheet" "suggest-update" "sunrise-sunset" "superword-mode" "text-scale-set" "tildify-buffer" "tildify-region" "titdic-convert" "trace-function" "undo-tree-mode" "undo-tree-redo" "unload-feature" "unmorse-region" "vc-create-repo" "vc-delete-file" "vc-dir-isearch" "vc-dir-refresh" "vc-next-action" "vc-rename-file" "vdiff-buffers3" "view-emacs-FAQ" "widget-forward" "windmove-right" "xref-goto-xref" "xref-next-line" "xref-prev-line" "yank-rectangle" "yas-next-field" "yas-prev-field" "yas-reload-all" "yas/minor-mode" "yas/next-field" "yas/prev-field" "yas/reload-all" "zap-up-to-char" "Info-cease-edit" "Info-final-node" "Info-index-next" "ad-activate-all" "ad-unadvise-all" "add-mode-abbrev" "advertised-undo" "apropos-command" "apropos-library" "auto-lower-mode" "auto-raise-mode" "autoarg-kp-mode" "avy-goto-char-2" "avy-goto-word-0" "avy-goto-word-1" "avy-kill-region" "avy-move-region" "backward-button" "balance-windows" "bookmark-delete" "bookmark-insert" "bookmark-locate" "bookmark-rename" "browse-url-mail" "buffer-face-set" "c-guess-install" "calendar-redraw" "calendar-unmark" "capitalize-dwim" "capitalize-word" "change-log-mode" "checkdoc-ispell" "clear-rectangle" "close-rectangle" "comint-send-eof" "command-apropos" "company-dabbrev" "company-oddmuse" "company-version" "compare-windows" "complete-symbol" "conf-colon-mode" "conf-space-mode" "counsel-apropos" "counsel-company" "counsel-git-log" "counsel-ibuffer" "counsel-org-tag" "counsel-outline" "counsel-package" "counsel-recentf" "customize-rogue" "customize-saved" "cvs-bury-buffer" "cvs-status-mode" "describe-symbol" "describe-syntax" "diff-apply-hunk" "diff-minor-mode" "dired-do-delete" "dired-do-rename" "dired-do-search" "dired-find-file" "dired-goto-file" "dired-next-line" "dired-tree-down" "dired-view-file" "disable-command" "dns-lookup-host" "doc-file-to-man" "downcase-region" "ebnf-eps-buffer" "ebnf-eps-region" "ebnf-find-style" "ebnf-print-file" "ebnf-push-style" "ebnf-spool-file" "edebug-all-defs" "ediff-customize" "elint-directory" "emacs-init-time" "emacs-lock-mode" "epa-delete-keys" "epa-exit-buffer" "epa-export-keys" "epa-file-enable" "epa-import-keys" "epa-insert-keys" "epa-mail-verify" "epa-sign-region" "epa-verify-file" "erc-add-keyword" "erc-button-mode" "erc-delete-fool" "erc-identd-stop" "erc-notify-mode" "eros-eval-defun" "eudc-query-form" "eudc-set-server" "eval-expression" "evil-a-sentence" "evil-align-left" "evil-buffer-new" "evil-close-fold" "evil-commentary" "evil-expat-tput" "evil-goto-error" "evil-inner-WORD" "evil-inner-word" "evil-lion-right" "evil-local-mode" "evil-magit-init" "evil-next-match" "evil-open-above" "evil-open-below" "evil-open-folds" "evil-org-delete" "evil-org-return" "evil-repeat-pop" "evil-set-marker" "evil-shift-left" "evil-show-files" "evil-show-jumps" "evil-show-marks" "evil-substitute" "evil-window-mru" "evil-window-new" "evil-window-top" "exit-minibuffer" "facemenu-update" "ffap-submit-bug" "find-grep-dired" "find-name-dired" "find-tag-regexp" "flycheck-manual" "forms-find-file" "fortune-compile" "fortune-message" "forward-to-word" "garbage-collect" "gdb-script-mode" "git-commit-mode" "git-commit-test" "git-rebase-mode" "global-ede-mode" "gnus-batch-kill" "gnus-score-mode" "goto-next-locus" "handle-focus-in" "haskell-compile" "haskell-version" "help-go-forward" "help-make-xrefs" "hide-ifdef-mode" "ibuffer-bs-show" "ibuffer-do-eval" "ibuffer-do-save" "ibuffer-do-view" "ido-enter-dired" "ido-insert-file" "ido-kill-buffer" "ido-select-text" "ido-toggle-case" "image-mode-menu" "image-next-file" "image-next-line" "image-scroll-up" "indent-relative" "inferior-octave" "info-xref-check" "insert-register" "isearch-mouse-2" "ispell-continue" "ivy-delete-char" "ivy-next-action" "ivy-occur-click" "ivy-occur-press" "ivy-prev-action" "ivy-read-action" "ivy-rotate-sort" "ivy-switch-view" "ivy-yank-symbol" "kbd-macro-query" "kill-whole-line" "lisp-eval-defun" "local-unset-key" "magit-blob-mode" "magit-blob-next" "magit-diff-dwim" "magit-diff-mode" "magit-dired-log" "magit-fetch-all" "magit-file-mode" "magit-gitignore" "magit-log-popup" "magit-mode-menu" "magit-next-line" "magit-push-tags" "magit-refs-mode" "magit-run-popup" "magit-show-refs" "magit-stash-pop" "magit-tag-popup" "magit-tag-prune" "magit-visit-ref" "make-empty-face" "markdown-demote" "markdown-export" "maximize-window" "message-forward" "message-goto-cc" "message-goto-to" "message-recover" "metamail-buffer" "metamail-region" "minimize-window" "mml-attach-file" "mml-insert-part" "mml-secure-sign" "mode-line-widen" "mouse-drag-drag" "mouse-set-point" "narrow-to-defun" "next-completion" "ns-print-buffer" "occur-edit-mode" "open-termscript" "org-agenda-list" "org-beamer-mode" "org-ctrl-c-star" "org-cut-special" "org-cut-subtree" "org-delete-char" "org-end-of-item" "org-end-of-line" "org-feed-update" "org-get-tags-at" "org-indent-item" "org-indent-line" "org-insert-item" "org-insert-link" "org-list-repair" "org-meta-return" "org-mobile-pull" "org-mobile-push" "org-odt-convert" "org-priority-up" "org-publish-all" "org-remove-file" "org-search-view" "org-set-tags-to" "org-shiftmetaup" "org-sparse-tree" "org-table-align" "org-timer-start" "org-toggle-item" "orgstruct-error" "outline-promote" "outshine-agenda" "play-sound-file" "pop-global-mark" "pr-ps-fast-fire" "pr-toggle-faces" "pr-toggle-spool" "pr-toggle-zebra" "previous-buffer" "ps-line-lengths" "ps-print-buffer" "ps-print-region" "ps-spool-buffer" "ps-spool-region" "quit-windows-on" "recover-session" "reftex-citation" "rename-uniquely" "rjsx-minor-mode" "rmail-add-label" "save-place-mode" "scroll-all-mode" "scroll-bar-drag" "scroll-bar-mode" "search-backward" "set-fill-column" "set-fill-prefix" "set-goal-column" "set-left-margin" "set-mouse-color" "smerge-keep-all" "smex-initialize" "sort-paragraphs" "spam-initialize" "start-kbd-macro" "studlify-buffer" "studlify-region" "tab-to-tab-stop" "table-recognize" "table-span-cell" "tags-table-mode" "tear-off-window" "testcover-start" "text-scale-mode" "transpose-chars" "transpose-lines" "transpose-sexps" "transpose-words" "type-break-mode" "unexpand-abbrev" "url-cookie-list" "url-cookie-mode" "vc-log-incoming" "vc-log-outgoing" "vc-next-comment" "vc-retrieve-tag" "vc-version-diff" "vdiff-3way-mode" "vdiff-hydra/nil" "vdiff-next-fold" "vdiff-next-hunk" "vdiff-open-fold" "view-emacs-news" "view-emacs-todo" "view-hello-file" "whitespace-mode" "widget-backward" "widget-complete" "woman-find-file" "x-set-selection" "xref-etags-mode" "yas-new-snippet" "yas/global-mode" "yas/new-snippet" "Buffer-menu-bury" "Buffer-menu-mark" "Buffer-menu-mode" "Buffer-menu-save" "Buffer-menu-sort" "Buffer-menu-view" "Custom-mode-menu" "Info-scroll-down" "Info-search-next" "ad-enable-advice" "ad-enable-regexp" "ad-remove-advice" "ad-update-regexp" "add-name-to-file" "append-next-kill" "append-to-buffer" "apropos-variable" "auto-insert-mode" "auto-revert-mode" "backward-to-word" "backward-up-list" "buffer-face-mode" "buffer-menu-open" "calc-grab-region" "center-paragraph" "change-log-merge" "cl-describe-type" "clojure-cycle-if" "common-lisp-mode" "company-box-mode" "company-complete" "company-keywords" "company-semantic" "compilation-mode" "copy-to-register" "copyright-update" "counsel-ace-link" "counsel-bookmark" "counsel-git-grep" "counsel-org-file" "counsel-org-goto" "counsel-semantic" "count-lines-page" "customize-browse" "customize-option" "customize-themes" "decode-hz-buffer" "decode-hz-region" "decompose-region" "delete-directory" "delete-rectangle" "describe-copying" "describe-fontset" "describe-package" "describe-project" "diff-ediff-patch" "diff-goto-source" "diff-hl-dir-mode" "diff-refine-hunk" "dired-async-mode" "dired-do-isearch" "dired-do-symlink" "dired-subtree-up" "doc-file-to-info" "easy-menu-remove" "ebnf-apply-style" "ebnf-merge-style" "ebnf-reset-style" "ebnf-syntax-file" "edebug-all-forms" "ediff-debug-info" "ediff-patch-file" "edt-emulation-on" "elint-initialize" "emerge-revisions" "encode-hz-buffer" "encode-hz-region" "epa-decrypt-file" "epa-encrypt-file" "epa-file-disable" "epa-mail-decrypt" "epa-mail-encrypt" "epl-install-file" "erc-identd-start" "evgeni--avy-line" "evgeni-run-macro" "evgeni-save-file" "evil-a-paragraph" "evil-align-right" "evil-append-line" "evil-change-line" "evil-close-folds" "evil-delete-char" "evil-delete-line" "evil-emacs-state" "evil-end-of-line" "evil-expat-gdiff" "evil-expat-tyank" "evil-goto-column" "evil-indent-line" "evil-inner-angle" "evil-inner-curly" "evil-inner-paren" "evil-insert-line" "evil-invert-case" "evil-invert-char" "evil-jump-to-tag" "evil-next-buffer" "evil-paste-after" "evil-prev-buffer" "evil-scroll-down" "evil-scroll-left" "evil-search-next" "evil-shift-right" "evil-toggle-fold" "evil-visual-char" "evil-visual-line" "evil-window-down" "evil-window-left" "evil-window-next" "evil-window-prev" "evil-window-vnew" "eww-search-words" "ffap-menu-rescan" "ffap-other-frame" "fixup-whitespace" "follow-scroll-up" "format-find-file" "forward-sentence" "full-calc-keypad" "gdb-enable-debug" "ghci-script-mode" "global-unset-key" "gnus-agent-batch" "gnus-batch-score" "gnus-fetch-group" "gnus-other-frame" "gnus-random-face" "go-download-play" "goto-last-change" "gud-tooltip-mode" "handle-focus-out" "haskell-describe" "haskell-doc-mode" "highlight-phrase" "highlight-regexp" "hl-todo-previous" "http-status-code" "ibuffer-do-occur" "ibuffer-do-print" "ido-display-file" "ido-load-history" "ido-save-history" "ido-toggle-trace" "ido-up-directory" "ido-wash-history" "image-goto-frame" "image-minor-mode" "image-mode-maybe" "image-next-frame" "indent-to-column" "info-lookup-file" "insert-kbd-macro" "isearch-backward" "isearch-complete" "isearch-del-char" "isearch-yank-pop" "ivy-forward-char" "ivy-toggle-fuzzy" "jump-to-register" "kill-all-abbrevs" "kill-compilation" "kill-this-buffer" "kill-visual-line" "kmacro-end-macro" "kmacro-swap-ring" "lisp-indent-line" "macrostep-expand" "magit-abort-dwim" "magit-bisect-bad" "magit-bisect-run" "magit-blame-echo" "magit-blame-mode" "magit-blame-quit" "magit-diff-paths" "magit-dired-jump" "magit-ediff-dwim" "magit-go-forward" "magit-merge-into" "magit-notes-edit" "magit-patch-save" "magit-popup-help" "magit-popup-info" "magit-popup-mode" "magit-popup-quit" "magit-pull-popup" "magit-push-popup" "magit-remote-add" "magit-reset-hard" "magit-reset-head" "magit-reset-soft" "magit-section-up" "magit-stage-file" "magit-stash-drop" "magit-stash-list" "magit-stash-mode" "magit-stash-show" "magit-tag-delete" "magit-wip-commit" "magit-zap-caches" "mail-add-payment" "mail-other-frame" "make-face-italic" "make-face-unbold" "markdown-move-up" "markdown-preview" "markdown-promote" "markdown-up-list" "message-followup" "message-goto-bcc" "message-goto-eoh" "message-goto-fcc" "mml-quote-region" "mouse-drag-throw" "mouse-set-region" "mouse-wheel-mode" "move-end-of-line" "move-text-region" "move-to-tab-stop" "newsticker-start" "ns-do-hide-emacs" "occur-cease-edit" "occur-next-error" "org-babel-tangle" "org-cdlatex-mode" "org-clock-cancel" "org-clock-report" "org-comment-dwim" "org-copy-special" "org-copy-subtree" "org-copy-visible" "org-ctrl-c-minus" "org-down-element" "org-edit-special" "org-footnote-new" "org-indent-block" "org-mark-element" "org-mark-subtree" "org-mode-restart" "org-move-item-up" "org-outdent-item" "org-plot/gnuplot" "org-set-property" "org-show-subtree" "org-sort-entries" "org-table-create" "org-table-export" "org-table-import" "org-timestamp-up" "orgstruct++-mode" "outline-show-all" "outlinify-sticky" "pcomplete-expand" "pr-despool-print" "pr-ps-file-print" "pr-ps-mode-print" "pr-show-pr-setup" "pr-show-ps-setup" "pr-toggle-duplex" "pr-toggle-header" "pr-toggle-region" "pr-toggle-tumble" "pr-txt-directory" "pr-txt-fast-fire" "prog-indent-sexp" "projectile-dired" "quickurl-add-url" "read-abbrev-file" "recode-file-name" "rmail-kill-label" "scroll-down-line" "scroll-lock-mode" "set-border-color" "set-cursor-color" "set-default-font" "set-face-stipple" "set-fringe-style" "set-mark-command" "set-right-margin" "smerge-keep-base" "smerge-keep-mine" "smerge-mode-menu" "string-rectangle" "switch-to-buffer" "table-delete-row" "table-insert-row" "table-split-cell" "table-widen-cell" "tcl-help-on-word" "timeclock-change" "toggle-read-only" "toggle-word-wrap" "translate-region" "uce-reply-to-uce" "uncomment-region" "underline-region" "untrace-function" "url-handler-mode" "use-package-lint" "vc-check-headers" "vc-clear-context" "vc-dir-find-file" "vc-dir-kill-line" "vc-dir-next-line" "vc-git-stash-pop" "vc-register-with" "vc-revert-buffer" "vc-version-ediff" "vdiff-close-fold" "vdiff-magit-dwim" "visit-tags-table" "widget-browse-at" "widget-kill-line" "with-editor-mode" "xterm-mouse-mode" "yas-exit-snippet" "yas/exit-snippet" "Info-forward-node" "Info-history-back" "ad-deactivate-all" "ad-disable-advice" "ad-disable-regexp" "add-global-abbrev" "avy-goto-symbol-1" "backward-sentence" "basic-save-buffer" "bibtex-initialize" "bibtex-style-mode" "blink-cursor-mode" "bookmark-relocate" "browse-url-chrome" "browse-url-elinks" "browse-url-galeon" "browse-url-mosaic" "bs-cycle-previous" "calendar-set-mark" "capitalize-region" "checkdoc-comments" "checkdoc-continue" "choose-completion" "clean-buffer-list" "comint-accumulate" "comint-kill-input" "comint-next-input" "comint-send-input" "company-next-page" "company-yasnippet" "conf-desktop-mode" "conf-windows-mode" "counsel-git-stash" "counsel-linux-app" "counsel-mark-ring" "counsel-rhythmbox" "crm-complete-word" "css-lookup-symbol" "customize-apropos" "customize-changed" "customize-unsaved" "dbus-handle-event" "define-mail-alias" "delete-windows-on" "describe-bindings" "diff-fixup-modifs" "diff-hl-next-hunk" "dired-backup-diff" "dired-do-compress" "dired-do-hardlink" "dired-goto-subdir" "dired-hide-subdir" "dired-kill-subdir" "dired-next-subdir" "dired-other-frame" "dired-prev-subdir" "dired-subtree-end" "display-call-tree" "display-time-mode" "dissociated-press" "ebnf-delete-style" "ebnf-insert-style" "ebnf-print-buffer" "ebnf-print-region" "ebnf-spool-buffer" "ebnf-spool-region" "ebrowse-save-tree" "ebrowse-tree-mode" "ediff-copy-A-to-B" "ediff-copy-A-to-C" "ediff-copy-B-to-A" "ediff-copy-B-to-C" "ediff-copy-C-to-A" "ediff-copy-C-to-B" "ediff-directories" "ediff-merge-files" "ediff-save-buffer" "ediff-status-info" "ediff-toggle-help" "edit-abbrevs-mode" "epa-dired-do-sign" "epa-key-list-mode" "epa-verify-region" "erc-autojoin-mode" "erc-server-select" "erc-services-mode" "erc-spelling-mode" "erc-truncate-mode" "erc-xdcc-add-file" "ert-describe-test" "eshell-report-bug" "eudc-edit-hotlist" "evgeni-elisp-eval" "evil-a-back-quote" "evil-align-center" "evil-delete-marks" "evil-expat-gblame" "evil-expat-remove" "evil-expat-rename" "evil-find-char-to" "evil-forward-char" "evil-inner-symbol" "evil-insert-state" "evil-jump-forward" "evil-magit-revert" "evil-motion-state" "evil-paste-before" "evil-record-macro" "evil-scroll-right" "evil-split-buffer" "evil-use-register" "evil-visual-block" "evil-visual-paste" "evil-visual-state" "evil-window-split" "facemenu-add-face" "facemenu-set-bold" "facemenu-set-face" "ff-get-other-file" "ffap-other-window" "find-tag-noselect" "finder-by-keyword" "finder-commentary" "format-write-file" "ghub-create-token" "ghub-token-scopes" "git-commit-review" "github-issue-mode" "gitlab-goto-issue" "gitlab-open-issue" "global-cwarn-mode" "global-eldoc-mode" "global-linum-mode" "gnus-bookmark-set" "gnus-button-reply" "gnus-sieve-update" "gofmt-before-save" "goto-address-mode" "gui-set-selection" "handle-move-frame" "haskell-c2hs-mode" "help-follow-mouse" "hydra-winner/body" "ibuffer-auto-mode" "ibuffer-customize" "ibuffer-do-delete" "ibuffer-do-revert" "ibuffer-find-file" "ibuffer-kill-line" "ibuffer-or-filter" "ibuffer-redisplay" "ido-insert-buffer" "ido-switch-buffer" "ido-toggle-ignore" "ido-toggle-prefix" "ido-toggle-regexp" "ido-wide-find-dir" "image-kill-buffer" "image-mode-as-hex" "image-reset-speed" "image-scroll-down" "image-scroll-left" "info-emacs-manual" "info-lookup-reset" "info-other-window" "isearch-mode-help" "isearch-yank-char" "isearch-yank-kill" "isearch-yank-line" "isearch-yank-word" "isearchb-activate" "iso-cvt-read-only" "ispell-pdict-save" "ivy-end-of-buffer" "ivy-previous-line" "ivy-toggle-ignore" "kill-some-buffers" "kmacro-call-macro" "kmacro-edit-macro" "kmacro-set-format" "kmacro-view-macro" "lua-start-process" "magit-am-continue" "magit-bisect-good" "magit-bisect-skip" "magit-blame-popup" "magit-cherry-mode" "magit-cherry-pick" "magit-diff-staged" "magit-ediff-popup" "magit-ediff-stage" "magit-fetch-popup" "magit-git-command" "magit-go-backward" "magit-log-current" "magit-log-refresh" "magit-merge-abort" "magit-merge-popup" "magit-notes-merge" "magit-notes-popup" "magit-notes-prune" "magit-patch-apply" "magit-patch-popup" "magit-rebase-edit" "magit-rebase-skip" "magit-reflog-head" "magit-reflog-mode" "magit-refresh-all" "magit-reset-index" "magit-reset-popup" "magit-run-git-gui" "magit-show-commit" "magit-stash-apply" "magit-stash-clear" "magit-stash-index" "magit-stash-popup" "magit-status-mode" "magit-subtree-add" "magit-tag-release" "magit-unstage-all" "magit-visit-thing" "mail-abbrevs-mode" "mail-other-window" "mark-whole-buffer" "markdown-complete" "markdown-shifttab" "markdown-show-all" "message-dont-send" "message-goto-body" "message-goto-from" "message-insert-to" "message-mode-menu" "message-supersede" "mml-attach-buffer" "mouse-buffer-menu" "mouse-drag-region" "mouse-select-font" "move-text-line-up" "negative-argument" "next-logical-line" "ns-do-hide-others" "ns-toggle-toolbar" "open-dribble-file" "org-clock-display" "org-clock-in-last" "org-ctrl-c-ctrl-c" "org-dblock-update" "org-edit-headline" "org-edit-src-code" "org-edit-src-exit" "org-edit-src-save" "org-edit-table.el" "org-entities-help" "org-goto-calendar" "org-id-get-create" "org-id-store-link" "org-indent-drawer" "org-indent-region" "org-insert-drawer" "org-open-at-mouse" "org-open-at-point" "org-paste-special" "org-paste-subtree" "org-previous-item" "org-previous-link" "org-priority-down" "org-return-indent" "org-shiftmetadown" "org-shiftmetaleft" "org-show-children" "org-show-priority" "org-table-convert" "org-table-iterate" "org-update-dblock" "orgtbl-ascii-plot" "orgtbl-send-table" "outline-hide-body" "outline-hide-more" "outline-next-line" "outline-show-more" "outlineify-sticky" "outshine-clock-in" "outshine-deadline" "outshine-priority" "outshine-schedule" "package-menu-mode" "package-reinstall" "pcomplete-reverse" "php-current-class" "point-to-register" "pp-eval-last-sexp" "pr-show-lpr-setup" "prepend-to-buffer" "process-menu-mode" "push-mark-command" "re-search-forward" "recentf-edit-list" "recentf-load-list" "recentf-save-list" "recover-this-file" "register-to-point" "replace-rectangle" "reposition-window" "rmail-epa-decrypt" "rng-validate-mode" "save-some-buffers" "scroll-up-command" "select-tags-table" "set-justification" "shadow-initialize" "shell-resync-dirs" "shell-script-mode" "shr-render-region" "smerge-keep-lower" "smerge-keep-other" "smerge-keep-upper" "smex-save-to-file" "strokes-do-stroke" "switch-to-haskell" "table-justify-row" "table-narrow-cell" "table-unrecognize" "thumbs-dired-show" "thumbs-find-thumb" "tmm-menubar-mouse" "todo-archive-mode" "toggle-rot13-mode" "toggle-save-place" "toggle-scroll-bar" "toggle-viper-mode" "turn-on-evil-mode" "url-cookie-delete" "vc-dir-hide-state" "vc-find-file-hook" "vc-git-stash-menu" "vc-git-stash-show" "vc-insert-headers" "vc-print-root-log" "vc-region-history" "vc-switch-backend" "vdiff-toggle-case" "whitespace-report" "widget-minor-mode" "with-editor-debug" "write-abbrev-file" "xref-find-apropos" "yas-abort-snippet" "yas-minor-mode-on" "yas-recompile-all" "yas/abort-snippet" "yas/minor-mode-on" "yas/recompile-all" "5x5-crack-randomly" "Buffer-menu-delete" "Buffer-menu-select" "Buffer-menu-unmark" "Custom-buffer-done" "Custom-goto-parent" "Custom-reset-saved" "Info-backward-node" "Info-last-preorder" "Info-next-preorder" "Info-nth-menu-item" "Info-virtual-index" "View-exit-and-edit" "abbrev-prefix-mark" "ad-activate-regexp" "append-to-register" "avy-goto-subword-0" "avy-goto-subword-1" "backward-kill-sexp" "backward-kill-word" "backward-paragraph" "beginning-of-defun" "bookmark-yank-word" "browse-url-firefox" "browse-url-generic" "browse-url-mozilla" "browse-url-of-file" "buffer-enable-undo" "buffer-face-toggle" "bug-reference-mode" "c-guess-no-install" "cal-tex-cursor-day" "calendar-goto-date" "cancel-debug-watch" "cfengine-auto-mode" "clojure-cycle-when" "clojure-unwind-all" "clojurescript-mode" "comint-kill-region" "comint-kill-subjob" "comint-magic-space" "comint-next-prompt" "comint-quit-subjob" "comint-show-output" "comint-stop-subjob" "comment-set-column" "company-restclient" "compile-goto-error" "compose-last-chars" "conf-javaprop-mode" "counsel-colors-web" "counsel-dired-jump" "counsel-org-entity" "count-lines-region" "count-words-region" "cua-selection-mode" "cursor-sensor-mode" "customize-variable" "dabbrev-completion" "define-mail-abbrev" "define-mode-abbrev" "defining-kbd-macro" "delete-blank-lines" "delete-indentation" "desktop-change-dir" "desktop-lazy-abort" "diary-insert-entry" "diary-mail-entries" "diary-mark-entries" "diary-view-entries" "diff-hl-amend-mode" "diff-hl-dired-mode" "diff-restrict-view" "dired-change-marks" "dired-display-file" "dired-do-redisplay" "dired-next-dirline" "dired-other-window" "dired-prev-dirline" "dired-subtree-down" "dired-toggle-marks" "dired-up-directory" "display-local-help" "display-time-world" "ebnf-eps-directory" "ebnf-syntax-buffer" "ebnf-syntax-region" "ebrowse-statistics" "ediff-current-file" "ediff-diff-to-diff" "ediff-directories3" "ediff-patch-buffer" "ediff-restore-diff" "ediff-swap-buffers" "ediff-toggle-hilit" "ediff-toggle-split" "ediff-update-diffs" "edit-indirect-save" "edmacro-insert-key" "elisp-index-search" "emacs-index-search" "end-of-visual-line" "epa-decrypt-region" "epa-encrypt-region" "erc-delete-keyword" "erc-timestamp-mode" "ethio-modify-vowel" "eudc-expand-inline" "evgeni--avy-region" "evgeni-inner-defun" "evil-Surround-edit" "evil-avy-goto-char" "evil-avy-goto-line" "evil-backward-char" "evil-complete-next" "evil-delete-buffer" "evil-ex-completion" "evil-ex-substitute" "evil-execute-macro" "evil-expat-gremove" "evil-expat-reverse" "evil-fill-and-move" "evil-inner-bracket" "evil-insert-resume" "evil-jump-backward" "evil-open-fold-rec" "evil-org-a-subtree" "evil-org-an-object" "evil-previous-line" "evil-replace-state" "evil-save-and-quit" "evil-set-selection" "evil-shell-command" "evil-surround-edit" "evil-surround-mode" "evil-visual-rotate" "evil-window-bottom" "evil-window-delete" "evil-window-middle" "evil-window-vsplit" "eww-list-bookmarks" "exit-splash-screen" "ff-find-other-file" "find-file-at-point" "find-file-existing" "flyspell-prog-mode" "follow-scroll-down" "format-insert-file" "forward-whitespace" "git-commit-signoff" "github-issues-mode" "gitlab--get-origin" "gitlab-close-issue" "gitlab-issues-mode" "gitlab-show-issues" "global-reveal-mode" "gmm-customize-mode" "gnus-bookmark-jump" "gnus-random-x-face" "gnus-update-format" "haskell-cabal-mode" "haskell-process-cd" "help-follow-symbol" "help-with-tutorial" "help-xref-interned" "htmlfontify-buffer" "hydra-pause-resume" "ibuffer-and-filter" "ibuffer-do-isearch" "ibuffer-pop-filter" "ibuffer-unmark-all" "ido-complete-space" "ido-display-buffer" "ido-imenu-anywhere" "ido-list-directory" "ido-make-directory" "ido-next-match-dir" "ido-next-work-file" "ido-prev-match-dir" "ido-prev-work-file" "ido-push-dir-first" "ido-toggle-literal" "ido-wide-find-file" "image-mode-as-text" "image-scroll-right" "increment-register" "indent-for-comment" "indented-text-mode" "info-complete-file" "info-lookup-symbol" "insert-parentheses" "intero-global-mode" "isearch-quote-char" "iso-cvt-write-only" "ispell-kill-ispell" "ispell-minor-check" "ivy-imenu-anywhere" "ivy-immediate-done" "ivy-insert-current" "ivy-kill-ring-save" "ivy-occur-dispatch" "ivy-toggle-calling" "kmacro-add-counter" "kmacro-bind-to-key" "kmacro-set-counter" "kmacro-start-macro" "kmacro-to-register" "lao-compose-region" "list-charset-chars" "list-input-methods" "locate-with-filter" "log-edit-mode-help" "log-edit-show-diff" "magit-bisect-popup" "magit-bisect-reset" "magit-bisect-start" "magit-branch-popup" "magit-branch-reset" "magit-cherry-apply" "magit-commit-amend" "magit-commit-fixup" "magit-commit-popup" "magit-delete-thing" "magit-diff-refresh" "magit-fetch-branch" "magit-file-untrack" "magit-format-patch" "magit-ignore-popup" "magit-log-branches" "magit-margin-popup" "magit-merge-absorb" "magit-merge-squash" "magit-notes-remove" "magit-process-kill" "magit-process-mode" "magit-push-current" "magit-rebase-abort" "magit-rebase-popup" "magit-remote-popup" "magit-remote-prune" "magit-request-pull" "magit-revert-popup" "magit-run-gitk-all" "magit-section-hide" "magit-section-show" "magit-stash-branch" "magit-stashes-mode" "magit-subtree-pull" "magit-subtree-push" "magit-unstage-file" "magit-update-index" "mail-check-payment" "make-face-unitalic" "make-frame-command" "make-frame-visible" "make-symbolic-link" "mark-end-of-buffer" "markdown-enter-key" "markdown-hide-body" "markdown-insert-hr" "markdown-mark-page" "markdown-mode-info" "markdown-mode-menu" "markdown-move-down" "markdown-next-link" "markdown-view-mode" "menu-bar-read-mail" "merge-mail-abbrevs" "message-split-line" "message-wide-reply" "mml-secure-encrypt" "mouse-yank-primary" "move-file-to-trash" "network-connection" "newline-and-indent" "ns-paste-secondary" "number-to-register" "org-agenda-columns" "org-agenda-to-appt" "org-align-all-tags" "org-babel-detangle" "org-capture-string" "org-demote-subtree" "org-edit-src-abort" "org-fill-paragraph" "org-hide-block-all" "org-insert-heading" "org-list-send-list" "org-mark-ring-goto" "org-mark-ring-push" "org-move-item-down" "org-previous-block" "org-resolve-clocks" "org-shiftcontrolup" "org-shiftmetaright" "org-show-block-all" "org-show-todo-tree" "org-table-kill-row" "org-table-move-row" "org-table-next-row" "org-timestamp-down" "org-todo-yesterday" "org-toggle-comment" "org-toggle-heading" "outline-hide-entry" "outline-show-entry" "outline-up-heading" "outorg-edit-as-org" "outshine-clock-out" "outshine-next-link" "package-initialize" "pcomplete-continue" "pr-despool-preview" "pr-printify-buffer" "pr-printify-region" "pr-ps-buffer-print" "pr-ps-file-preview" "pr-ps-mode-preview" "pr-ps-region-print" "projectile-ibuffer" "projectile-recentf" "projectile-replace" "projectile-ripgrep" "projectile-version" "ps-nb-pages-buffer" "ps-nb-pages-region" "ps-print-customize" "quickurl-edit-urls" "quickurl-list-mode" "re-search-backward" "recentf-open-files" "remember-clipboard" "rmail-get-new-mail" "rmail-last-message" "rmail-next-message" "rmail-only-expunge" "rmail-show-message" "rmail-sort-by-date" "rng-nxml-mode-init" "rot13-other-window" "set-comment-column" "set-face-underline" "shell-strip-ctrl-m" "smerge-resolve-all" "smex-find-function" "smex-rebuild-cache" "sort-regexp-fields" "speedbar-get-focus" "split-window-below" "split-window-right" "table-forward-cell" "table-justify-cell" "table-shorten-cell" "tags-loop-continue" "tags-query-replace" "tramp-unload-tramp" "turn-off-evil-mode" "turn-on-cwarn-mode" "unhighlight-regexp" "universal-argument" "ununderline-region" "vc-dir-delete-file" "vc-dir-toggle-mark" "vc-finish-logentry" "vc-git-stash-apply" "vdiff-save-buffers" "vdiff-send-changes" "view-order-manuals" "which-key-undo-key" "whitespace-cleanup" "widget-end-of-line" "window-swap-states" "with-editor-cancel" "with-editor-finish" "yas-insert-snippet" "yas-load-directory" "yas-tryout-snippet" "yas/insert-snippet" "yas/load-directory" "yas/tryout-snippet" "yenc-decode-region" "2C-associate-buffer" "Buffer-menu-execute" "Info-last-menu-item" "Info-next-menu-item" "Info-next-reference" "Info-prev-reference" "allout-widgets-mode" "ange-ftp-reread-dir" "apropos-local-value" "apropos-user-option" "async-shell-command" "avy-goto-line-above" "avy-goto-line-below" "avy-kill-whole-line" "beginning-of-buffer" "bibtex-search-entry" "blink-matching-open" "bookmark-bmenu-list" "bookmark-bmenu-load" "bookmark-bmenu-mark" "bookmark-bmenu-mode" "bookmark-bmenu-save" "bovine-grammar-mode" "browse-url-at-mouse" "browse-url-at-point" "browse-url-chromium" "browse-url-conkeror" "browse-url-epiphany" "browse-url-netscape" "browse-url-xdg-open" "buffer-disable-undo" "cal-tex-cursor-week" "cal-tex-cursor-year" "calc-grab-rectangle" "calendar-goto-today" "call-last-kbd-macro" "checkdoc-eval-defun" "checkdoc-minor-mode" "clojure-move-to-let" "comint-clear-buffer" "comint-insert-input" "comint-strip-ctrl-m" "comint-write-output" "company-search-mode" "company-select-next" "company-xcode-reset" "completion-at-point" "conf-space-keywords" "conf-xdefaults-mode" "copy-region-as-kill" "copyright-fix-years" "counsel-esh-history" "counsel-find-symbol" "counsel-hydra-heads" "counsel-org-capture" "crm-completion-help" "customize-set-value" "delete-forward-char" "delete-other-frames" "describe-categories" "diff-hl-margin-mode" "diff-tell-file-name" "dired-async-do-copy" "dired-do-kill-lines" "dired-do-relsymlink" "dired-insert-subdir" "dired-mark-symlinks" "dired-previous-line" "dired-single-buffer" "dired-subtree-cycle" "doc-view-minor-mode" "ebrowse-member-mode" "ebrowse-tags-search" "ediff-combine-diffs" "ediff-documentation" "ediff-merge-buffers" "ediff-reload-keymap" "ediff-show-registry" "ediff-submit-report" "edit-indirect-abort" "edit-last-kbd-macro" "edmacro-finish-edit" "electric-quote-mode" "elp-instrument-list" "enable-flow-control" "epa-dired-do-verify" "erc-completion-mode" "erc-truncate-buffer" "eros-eval-last-sexp" "ethio-replace-space" "evil-a-double-quote" "evil-a-single-quote" "evil-ex-line-number" "evil-ex-nohighlight" "evil-ex-search-exit" "evil-ex-search-next" "evil-goto-mark-line" "evil-inner-sentence" "evil-insert-digraph" "evil-last-non-blank" "evil-list-view-mode" "evil-move-to-column" "evil-multiedit-next" "evil-multiedit-prev" "evil-operator-state" "evil-org-an-element" "evil-org-open-above" "evil-org-open-below" "evil-org-open-links" "evil-paste-pop-next" "evil-previous-match" "evil-ret-and-indent" "evil-save-and-close" "evil-scroll-line-up" "evil-scroll-page-up" "evil-search-forward" "evil-show-file-info" "evil-show-registers" "evil-visual-restore" "exit-recursive-edit" "expand-mail-aliases" "facemenu-read-color" "facemenu-remove-all" "facemenu-set-italic" "ffap-alternate-file" "ffap-list-directory" "file-cache-add-file" "find-alternate-file" "find-file-literally" "find-file-read-only" "fit-frame-to-buffer" "fortune-add-fortune" "fortune-from-region" "forward-same-syntax" "git-commit-modified" "git-commit-reported" "github-issue-browse" "gitlab-goto-project" "global-company-mode" "global-hi-lock-mode" "global-hl-line-mode" "global-origami-mode" "global-subword-mode" "gnus-draft-reminder" "gnus-face-from-file" "gnus-sieve-generate" "handle-delete-frame" "handle-switch-frame" "haskell-indent-mode" "helm-imenu-anywhere" "hi-lock-face-buffer" "highlight-uses-mode" "hydra-amaranth-warn" "hydra-keyboard-quit" "ibuffer-bury-buffer" "ido-completion-help" "ido-enter-find-file" "ido-exit-minibuffer" "image-decrease-size" "image-increase-size" "image-previous-file" "image-previous-line" "image-reverse-speed" "indent-code-rigidly" "indent-rigidly-left" "info-display-manual" "info-xref-check-all" "isearch-delete-char" "isearch-edit-string" "isearch-toggle-word" "isearch-xterm-paste" "iso-cvt-define-menu" "ivy-kill-whole-line" "ivy-minibuffer-grow" "ivy-occur-grep-mode" "ivy-occur-next-line" "ivy-partial-or-done" "jit-lock-debug-mode" "kill-current-buffer" "kill-local-variable" "kmacro-edit-lossage" "linum-relative-mode" "lisp-fill-paragraph" "list-character-sets" "list-coding-systems" "list-matching-lines" "log-edit-show-files" "magit-blame-removal" "magit-blame-reverse" "magit-blob-previous" "magit-branch-delete" "magit-branch-orphan" "magit-branch-rename" "magit-branch-shelve" "magit-cherry-donate" "magit-commit-extend" "magit-commit-reword" "magit-commit-squash" "magit-diff-unmerged" "magit-diff-unstaged" "magit-ediff-compare" "magit-ediff-resolve" "magit-fetch-modules" "magit-fetch-refspec" "magit-file-checkout" "magit-merge-editmsg" "magit-merge-preview" "magit-previous-line" "magit-push-matching" "magit-push-refspecs" "magit-rebase-subset" "magit-remote-remove" "magit-remote-rename" "magit-repolist-mode" "magit-revision-mode" "magit-section-cycle" "magit-shell-command" "magit-submodule-add" "magit-subtree-merge" "magit-subtree-popup" "magit-subtree-split" "magit-toggle-margin" "make-local-variable" "makefile-gmake-mode" "makefile-imake-mode" "markdown-check-refs" "markdown-insert-kbd" "markdown-insert-pre" "markdown-insert-uri" "markdown-mark-block" "markdown-outline-up" "markdown-pre-region" "markdown-standalone" "markdown-up-heading" "message-bold-region" "message-cancel-news" "message-kill-buffer" "message-widen-reply" "message-yank-buffer" "mh-fully-kill-draft" "minibuffer-complete" "mml-attach-external" "mml-secure-sign-pgp" "modify-syntax-entry" "mouse-delete-window" "mouse-drag-top-edge" "mouse-popup-menubar" "mouse-select-window" "mouse-set-secondary" "mouse-yank-at-click" "move-text-line-down" "move-text-region-up" "move-to-left-margin" "move-to-window-line" "multi-isearch-files" "name-last-kbd-macro" "newsticker-treeview" "ns-popup-font-panel" "ns-put-working-text" "ns-spi-service-call" "occur-rename-buffer" "org-archive-subtree" "org-at-date-range-p" "org-babel-load-file" "org-babel-sha1-hash" "org-calendar-select" "org-cancel-repeater" "org-check-deadlines" "org-columns-compute" "org-delete-property" "org-export-dispatch" "org-feed-goto-inbox" "org-feed-update-all" "org-first-sibling-p" "org-footnote-action" "org-forward-element" "org-hugo-debug-info" "org-move-subtree-up" "org-narrow-to-block" "org-promote-subtree" "org-property-action" "org-publish-project" "org-reftex-citation" "org-speed-move-safe" "org-table-copy-down" "org-timer-set-timer" "org-toggle-checkbox" "org-transpose-words" "org-unindent-buffer" "outline-hide-leaves" "outshine-clock-goto" "outshine-inc-effort" "outshine-set-effort" "outshine-time-stamp" "outshine-timer-item" "package-menu-filter" "pending-delete-mode" "pop-to-mark-command" "pr-despool-ps-print" "pr-ps-file-ps-print" "pr-ps-mode-ps-print" "pr-toggle-landscape" "prepend-to-register" "previous-completion" "project-find-regexp" "projectile-find-dir" "projectile-find-tag" "projectile-run-term" "quickurl-browse-url" "recenter-top-bottom" "recentf-dialog-mode" "rectangle-left-char" "rectangle-mark-mode" "rectangle-next-line" "rmail-first-message" "rmail-redecode-body" "rmail-retry-failure" "rmail-sort-by-lines" "rmail-toggle-header" "rotate-yank-pointer" "run-with-idle-timer" "scroll-down-command" "scroll-other-window" "self-insert-command" "server-force-delete" "server-generate-key" "set-face-background" "set-face-foreground" "shell-dirtrack-mode" "smerge-auto-combine" "smerge-context-menu" "smerge-keep-current" "smerge-kill-current" "sort-numeric-fields" "speedbar-frame-mode" "swiper-from-isearch" "table-backward-cell" "table-delete-column" "table-heighten-cell" "table-insert-column" "tabulated-list-mode" "tabulated-list-sort" "text-scale-decrease" "text-scale-increase" "thai-compose-buffer" "thai-compose-region" "tramp-change-syntax" "transpose-sentences" "turn-on-haskell-doc" "turn-on-iimage-mode" "undo-tree-visualize" "variable-pitch-mode" "vc-dir-display-file" "vc-git-log-incoming" "vc-git-log-outgoing" "vc-hg-log-view-mode" "vc-previous-comment" "vc-print-branch-log" "vc-toggle-read-only" "vdiff-magit-compare" "vdiff-magit-resolve" "vdiff-previous-fold" "vdiff-previous-hunk" "vdiff-switch-buffer" "view-emacs-problems" "which-function-mode" "widget-button-click" "widget-button-press" "window-divider-mode" "wisent-grammar-mode" "word-search-forward" "yas/describe-tables" "5x5-crack-xor-mutate" "Buffer-menu-1-window" "Buffer-menu-2-window" "Custom-reset-current" "Info-history-forward" "Info-mouse-scroll-up" "Info-search-backward" "abort-recursive-edit" "ad-activate-internal" "ad-deactivate-regexp" "ad-recover-normality" "add-change-log-entry" "align-highlight-rule" "all-the-icons-insert" "ange-ftp-re-read-dir" "auto-encryption-mode" "auto-image-file-mode" "backward-delete-char" "balance-windows-area" "base64-decode-region" "base64-encode-region" "binhex-decode-region" "browse-url-gnome-moz" "browse-url-of-buffer" "browse-url-of-region" "byte-force-recompile" "cal-html-cursor-year" "cal-tex-cursor-month" "cal-tex-cursor-week2" "calendar-basic-setup" "calendar-end-of-week" "calendar-end-of-year" "calendar-forward-day" "calendar-other-month" "calendar-scroll-left" "change-log-find-file" "check-ispell-version" "checkdoc-interactive" "comint-delete-output" "comint-restore-input" "company-dabbrev-code" "company-search-abort" "company-select-mouse" "completion-list-mode" "counsel-git-checkout" "counsel-load-library" "counsel-org-goto-all" "counsel-unicode-char" "counsel-up-directory" "cpp-highlight-buffer" "customize-customized" "decode-coding-region" "decrease-left-margin" "define-global-abbrev" "delete-backward-char" "delete-other-windows" "describe-gnu-project" "describe-key-briefly" "describe-no-warranty" "diff-hl-flydiff-mode" "dired-do-compress-to" "dired-do-copy-regexp" "dired-do-find-regexp" "dired-show-file-type" "dired-subtree-insert" "dired-subtree-narrow" "dired-subtree-remove" "dired-subtree-revert" "dired-subtree-toggle" "display-about-screen" "display-battery-mode" "docker-tramp-cleanup" "ebnf-print-directory" "ebnf-spool-directory" "ebrowse-save-tree-as" "ediff-next-meta-item" "ediff-show-dir-diffs" "edir-merge-revisions" "edit-indirect-commit" "edit-indirect-region" "edit-named-kbd-macro" "electric-buffer-list" "electric-layout-mode" "elint-current-buffer" "elisp-byte-code-mode" "encode-coding-region" "epa-dired-do-decrypt" "epa-dired-do-encrypt" "epa-global-mail-mode" "epa-list-secret-keys" "epa-mail-import-keys" "erc-speedbar-browser" "erc-track-minor-mode" "eudc-try-bbdb-insert" "eval-print-last-sexp" "evgeni-window-vsplit" "evil-Surround-region" "evil-avy-goto-char-2" "evil-avy-goto-word-0" "evil-avy-goto-word-1" "evil-collection-init" "evil-commentary-mode" "evil-copy-from-above" "evil-copy-from-below" "evil-ex-search-abort" "evil-exchange-cancel" "evil-expat-diff-orig" "evil-first-non-blank" "evil-goto-definition" "evil-goto-first-line" "evil-inner-paragraph" "evil-join-whitespace" "evil-multiedit-abort" "evil-org-append-line" "evil-org-delete-char" "evil-org-end-of-line" "evil-org-insert-line" "evil-repeat-pop-next" "evil-search-backward" "evil-search-previous" "evil-shift-left-line" "evil-surround-change" "evil-surround-delete" "evil-surround-region" "evil-window-top-left" "executable-interpret" "executable-set-magic" "facemenu-set-default" "ff-find-related-file" "find-face-definition" "find-function-on-key" "find-lisp-find-dired" "find-tag-other-frame" "finder-list-keywords" "format-decode-buffer" "format-decode-region" "format-encode-buffer" "format-encode-region" "fortune-to-signature" "frameset-to-register" "ghc-core-create-core" "git-commit-mode-menu" "git-commit-suggested" "github-issue-refresh" "gitlab-projects-mode" "gitlab-show-projects" "global-flycheck-mode" "gnus-slave-no-server" "gnus-slave-unplugged" "goto-history-element" "handle-select-window" "haskell-forward-sexp" "haskell-session-kill" "haskell-sort-imports" "help-at-pt-set-timer" "ibuffer-change-marks" "ibuffer-forward-line" "ibuffer-list-buffers" "ibuffer-mark-by-mode" "ibuffer-mark-forward" "ibuffer-other-window" "ibuffer-save-filters" "ibuffer-toggle-marks" "ibuffer-visit-buffer" "ido-fallback-command" "ido-find-file-in-dir" "ido-reread-directory" "ido-take-first-match" "iedit-rectangle-mode" "image-decrease-speed" "image-increase-speed" "image-mode-fit-frame" "image-previous-frame" "image-toggle-display" "imenu-add-to-menubar" "increase-left-margin" "indent-rigidly-right" "info-complete-symbol" "info-xref-docstrings" "isearch-char-by-name" "isearch-describe-key" "isearch-forward-word" "isearch-ring-advance" "isearch-ring-retreat" "ispell-check-version" "ispell-complete-word" "ivy-dispatching-call" "ivy-dispatching-done" "ivy-reverse-i-search" "ivy-toggle-case-fold" "justify-current-line" "keyboard-escape-quit" "kmacro-call-ring-2nd" "kmacro-view-ring-2nd" "lisp-complete-symbol" "list-command-history" "log-edit-kill-buffer" "magit-branch-spinoff" "magit-checkout-stage" "magit-cherry-harvest" "magit-cherry-spinoff" "magit-cherry-spinout" "magit-commit-add-log" "magit-commit-augment" "magit-diff-flip-revs" "magit-dispatch-popup" "magit-jump-to-staged" "magit-merge-nocommit" "magit-process-buffer" "magit-push-to-remote" "magit-reflog-current" "magit-reshelve-since" "magit-section-toggle" "magit-sequencer-skip" "magit-set-remote*url" "magit-show-refs-head" "magit-snapshot-index" "magit-stage-modified" "magit-stash-worktree" "magit-worktree-popup" "make-command-summary" "make-frame-invisible" "make-indirect-buffer" "makefile-makepp-mode" "mark-end-of-sentence" "markdown-end-of-list" "markdown-indent-line" "markdown-insert-bold" "markdown-insert-code" "markdown-insert-link" "markdown-table-align" "markdown-toggle-math" "markdown-unused-refs" "menu-bar-select-yank" "message-elide-region" "message-goto-subject" "message-goto-summary" "message-kill-address" "message-sort-headers" "message-to-list-only" "messages-buffer-mode" "mml-insert-multipart" "mml-unsecure-message" "mode-line-change-eol" "mouse-avoidance-mode" "mouse-drag-left-edge" "mouse-drag-mode-line" "mouse-drag-secondary" "mouse-kill-ring-save" "mouse-kill-secondary" "mouse-save-then-kill" "mouse-yank-secondary" "newsticker-plainview" "newsticker-show-news" "next-error-no-select" "next-history-element" "ns-popup-color-panel" "org-babel-lob-ingest" "org-babel-mark-block" "org-backward-element" "org-check-after-date" "org-decompose-region" "org-delete-directory" "org-end-of-item-list" "org-forward-sentence" "org-indent-item-tree" "org-indent-to-column" "org-insert-all-links" "org-set-tags-command" "org-shiftcontroldown" "org-shiftcontrolleft" "org-table-cut-region" "org-table-edit-field" "org-table-fedit-menu" "org-table-field-info" "org-table-insert-row" "org-table-next-field" "org-table-sort-lines" "org-tags-sparse-tree" "org-timestamp-up-day" "orgtbl-ctrl-c-ctrl-c" "outline-hide-subtree" "outline-mark-subtree" "outline-next-heading" "outline-show-subtree" "outshine-insert-link" "outshine-timer-start" "override-global-mode" "package-install-file" "package-menu-execute" "package-menu-refresh" "posix-search-forward" "pr-ps-buffer-preview" "pr-ps-region-preview" "prefer-coding-system" "projectile-commander" "projectile-run-shell" "query-replace-regexp" "rebuild-mail-abbrevs" "rectangle-right-char" "remember-other-frame" "rmail-delete-forward" "rmail-delete-message" "rmail-end-of-message" "rmail-output-as-seen" "rmail-sort-by-author" "rmail-sort-by-labels" "scan-buf-next-region" "scroll-bar-scroll-up" "select-frame-by-name" "self-insert-and-exit" "set-background-color" "set-face-underline-p" "set-foreground-color" "set-rmail-inbox-list" "smerge-start-session" "sp-forward-barf-sexp" "spam-report-agentize" "strokes-list-strokes" "swiper-query-replace" "table-justify-column" "table-recognize-cell" "testcover-this-defun" "thumbs-dired-setroot" "thumbs-show-from-dir" "timeclock-reread-log" "toggle-debug-on-quit" "transpose-paragraphs" "vc-dir-previous-line" "vc-git-log-edit-mode" "vc-git-log-view-mode" "vc-resolve-conflicts" "vc-update-change-log" "vdiff-merge-conflict" "vdiff-open-all-folds" "view-emacs-debugging" "what-cursor-position" "whois-reverse-lookup" "word-search-backward" "xref-find-references" "yas--minor-mode-menu" "Custom-reset-standard" "Info-follow-reference" "Info-speedbar-browser" "apropos-documentation" "auto-composition-mode" "auto-compression-mode" "auto-revert-set-timer" "auto-revert-tail-mode" "avy-goto-char-2-above" "avy-goto-char-2-below" "avy-goto-char-in-line" "avy-goto-word-0-above" "avy-goto-word-0-below" "avy-goto-word-1-above" "avy-goto-word-1-below" "binary-overwrite-mode" "bookmark-bmenu-delete" "bookmark-bmenu-locate" "bookmark-bmenu-rename" "bookmark-bmenu-search" "bookmark-bmenu-select" "bookmark-bmenu-unmark" "bookmark-set-internal" "browse-url-text-emacs" "browse-url-text-xterm" "browse-url-w3-gnudoit" "cal-html-cursor-month" "calendar-backward-day" "calendar-end-of-month" "calendar-forward-week" "calendar-forward-year" "calendar-lunar-phases" "calendar-scroll-right" "cancel-debug-on-entry" "change-log-next-error" "checkdoc-ispell-defun" "checkdoc-message-text" "checkdoc-rogue-spaces" "clipboard-kill-region" "clojure-cycle-privacy" "clojure-introduce-let" "clone-indirect-buffer" "comint-copy-old-input" "comint-previous-input" "company-begin-backend" "company-other-backend" "company-previous-page" "company-search-keypad" "company-show-location" "compilation-next-file" "counsel-describe-face" "counsel-file-register" "counsel-shell-history" "crm-complete-and-exit" "decrease-right-margin" "delete-matching-lines" "delete-selection-mode" "describe-distribution" "describe-input-method" "desktop-lazy-complete" "diff-auto-refine-mode" "diff-context->unified" "diff-hl-previous-hunk" "diff-unified->context" "dired-async-do-rename" "dired-clean-directory" "dired-do-byte-compile" "dired-mouse-find-file" "dired-unmark-backward" "ebnf-syntax-directory" "ediff-merge-revisions" "ediff-meta-show-patch" "ediff-next-difference" "ediff-registry-action" "ediff-shrink-window-C" "edit-abbrevs-redefine" "eldoc-eval-expression" "erc-nickserv-identify" "evgeni-evil-multiedit" "evil-ex-show-digraphs" "evil-exit-emacs-state" "evil-forward-WORD-end" "evil-forward-word-end" "evil-inner-back-quote" "evil-next-close-brace" "evil-next-close-paren" "evil-next-visual-line" "evil-org-inner-object" "evil-read-quoted-char" "evil-repeat-find-char" "evil-scroll-line-down" "evil-scroll-page-down" "evil-shift-right-line" "evil-window-set-width" "exchange-dot-and-mark" "expand-region-abbrevs" "file-name-shadow-mode" "find-file-other-frame" "find-tag-other-window" "github-issues-refresh" "global-font-lock-mode" "global-superword-mode" "global-undo-tree-mode" "gnus-agent-regenerate" "gnus-delay-send-queue" "gnus-treat-from-picon" "gnus-treat-mail-picon" "gnus-x-face-from-file" "goto-address-at-mouse" "goto-address-at-point" "haskell-align-imports" "haskell-collapse-mode" "haskell-doc-show-type" "haskell-mode-goto-loc" "haskell-mode-tag-find" "haskell-process-cabal" "haskell-process-clear" "hi-lock-unface-buffer" "hindent-reformat-decl" "hindent/reformat-decl" "hydra--digit-argument" "ibuffer-backward-line" "ibuffer-bs-toggle-all" "ibuffer-do-kill-lines" "ibuffer-negate-filter" "ibuffer-switch-format" "icalendar-export-file" "icalendar-import-file" "ido-copy-current-word" "ido-dired-other-frame" "ido-enter-insert-file" "ido-magic-delete-char" "image-dired-tag-files" "image-forward-hscroll" "image-transform-reset" "increase-right-margin" "indent-relative-maybe" "indian-compose-region" "insert-file-literally" "intero-mode-blacklist" "intero-mode-whitelist" "isearch-complete-edit" "isearch-describe-mode" "isearch-help-for-help" "isearch-printing-char" "isearch-query-replace" "isearch-toggle-regexp" "isearch-toggle-symbol" "ivy-call-and-recenter" "ivy-minibuffer-shrink" "ivy-occur-read-action" "ivy-scroll-up-command" "js2-imenu-extras-mode" "kill-backward-up-list" "kill-matching-buffers" "kmacro-end-call-mouse" "kmacro-insert-counter" "literate-haskell-mode" "log-edit-next-comment" "magit-blame-copy-hash" "magit-branch-checkout" "magit-branch-unshelve" "magit-commit-reshelve" "magit-diff-visit-file" "magit-emacs-Q-command" "magit-fetch-all-prune" "magit-jump-to-stashes" "magit-jump-to-tracked" "magit-list-submodules" "magit-log-buffer-file" "magit-log-bury-buffer" "magit-log-select-mode" "magit-log-select-pick" "magit-log-select-quit" "magit-popup-help-mode" "magit-push-implicitly" "magit-rebase-continue" "magit-remote-set-head" "magit-repolist-status" "magit-section-forward" "magit-sequencer-abort" "magit-set-remote*push" "magit-show-refs-popup" "magit-submodule-popup" "magit-wip-log-current" "magit-worktree-branch" "magit-worktree-delete" "magit-worktree-status" "mail-abbrev-next-line" "make-face-bold-italic" "make-frame-on-display" "makefile-bsdmake-mode" "markdown-forward-page" "markdown-hide-subtree" "markdown-insert-image" "markdown-mark-subtree" "markdown-other-window" "markdown-outline-next" "markdown-show-subtree" "markdown-show-version" "menu-bar-options-save" "menu-bar-read-lispref" "message-caesar-region" "message-goto-keywords" "message-goto-reply-to" "message-rename-buffer" "message-send-and-exit" "message-unbold-region" "message-yank-original" "mh-smail-other-window" "mml-secure-sign-smime" "mode-line-bury-buffer" "mode-line-next-buffer" "mouse-appearance-menu" "mouse-drag-right-edge" "mouse-major-mode-menu" "mouse-minor-mode-menu" "mouse-start-secondary" "mouse-tear-off-window" "move-text-region-down" "multi-isearch-buffers" "ns-unput-working-text" "occur-mode-mouse-goto" "org-babel-tangle-file" "org-backward-sentence" "org-beginning-of-item" "org-beginning-of-line" "org-check-before-date" "org-check-dates-range" "org-cycle-list-bullet" "org-drag-line-forward" "org-edit-export-block" "org-edit-src-continue" "org-force-self-insert" "org-forward-paragraph" "org-hide-block-toggle" "org-hugo-export-as-md" "org-hugo-export-to-md" "org-insert-subheading" "org-list-make-subtree" "org-match-sparse-tree" "org-move-subtree-down" "org-narrow-to-element" "org-odt-export-as-odf" "org-odt-export-to-odt" "org-org-export-as-org" "org-org-export-to-org" "org-outdent-item-tree" "org-shiftcontrolright" "org-submit-bug-report" "org-table-blank-field" "org-table-copy-region" "org-table-fedit-abort" "org-table-goto-column" "org-table-move-column" "org-table-move-row-up" "org-table-recalculate" "org-table-wrap-region" "org-transpose-element" "orgtbl-toggle-comment" "outline-show-branches" "outline-show-children" "outshine-clock-cancel" "outshine-clock-report" "outshine-set-property" "package-list-packages" "php-current-namespace" "pkg-info-version-info" "posix-search-backward" "pr-printify-directory" "pr-ps-buffer-ps-print" "pr-ps-directory-print" "pr-ps-file-up-preview" "pr-ps-region-ps-print" "pr-toggle-file-duplex" "pr-toggle-file-tumble" "pr-toggle-ghostscript" "pr-toggle-upside-down" "prettify-symbols-mode" "previous-logical-line" "profiler-find-profile" "projectile--find-file" "projectile-run-eshell" "recentf-cancel-dialog" "repunctuate-sentences" "rfc2047-decode-region" "rmail-delete-backward" "rmail-sort-by-subject" "save-place-local-mode" "search-emacs-glossary" "search-forward-regexp" "set-selective-display" "set-visited-file-name" "shadow-define-cluster" "shell-dirtrack-toggle" "shell-forward-command" "show-smartparens-mode" "sieve-upload-and-bury" "sieve-upload-and-kill" "smerge-diff-base-mine" "srecode-template-mode" "strokes-decode-buffer" "switch-to-completions" "switch-to-next-buffer" "switch-to-prev-buffer" "table-generate-source" "table-insert-sequence" "table-query-dimension" "table-recognize-table" "tabulated-list-revert" "texinfo-format-buffer" "texinfo-format-region" "toggle-truncate-lines" "type-break-statistics" "vc-dir-isearch-regexp" "vc-dir-mark-all-files" "vc-dir-next-directory" "vc-dir-show-fileentry" "vc-dir-unmark-file-up" "vc-git-stash-snapshot" "vdiff--translate-line" "vdiff-close-all-folds" "vdiff-receive-changes" "vdiff-restore-windows" "view-file-other-frame" "which-key-show-keymap" "widget-field-activate" "woman-dired-find-file" "xref-pop-marker-stack" "yas-compile-directory" "yas-exit-all-snippets" "yas/compile-directory" "yas/exit-all-snippets" "Buffer-menu-unmark-all" "Info-mouse-follow-link" "Info-mouse-scroll-down" "Info-on-current-buffer" "add-dir-local-variable" "align-unhighlight-rule" "apropos-local-variable" "auto-save-visited-mode" "backward-kill-sentence" "beginning-of-defun-raw" "beginning-of-line-text" "calc-embedded-activate" "calendar-backward-week" "calendar-backward-year" "calendar-forward-month" "calendar-iso-goto-date" "calendar-iso-goto-week" "calendar-list-holidays" "calendar-mark-holidays" "cancel-function-timers" "capitalized-words-mode" "change-log-goto-source" "comint-continue-subjob" "comint-kill-whole-line" "comint-previous-prompt" "comint-truncate-buffer" "company-complete-mouse" "compilation-minor-mode" "compilation-next-error" "copy-rectangle-as-kill" "counsel-grep-or-swiper" "counsel-irony-callback" "counsel-list-processes" "counsel-org-tag-agenda" "counsel-yank-directory" "cperl-perldoc-at-point" "cursor-intangible-mode" "customize-set-variable" "delete-duplicate-lines" "delimit-columns-region" "describe-character-set" "describe-coding-system" "diary-show-all-entries" "diff-hl-changes-buffer" "diff-hl-diff-goto-hunk" "diff-mouse-goto-source" "diff-next-complex-hunk" "diff-reverse-direction" "dired-async-do-symlink" "dired-create-directory" "dired-do-rename-regexp" "dired-do-shell-command" "dired-mark-directories" "dired-next-marked-file" "dired-prev-marked-file" "dired-single-customize" "dired-toggle-read-only" "dired-unmark-all-files" "dired-unmark-all-marks" "ediff-filegroup-action" "ediff-quit-meta-buffer" "ediff-regions-linewise" "ediff-regions-wordwise" "ediff-show-diff-output" "ediff-show-meta-buffer" "ediff-toggle-read-only" "ediff-windows-linewise" "ediff-windows-wordwise" "edt-set-scroll-margins" "elp-instrument-package" "emacs-lisp-macroexpand" "epa-import-keys-region" "erc-add-dangerous-host" "erc-notifications-mode" "evgeni-hydra-zoom/body" "evgeni-narrow-or-widen" "evil-avy-goto-symbol-1" "evil-backward-WORD-end" "evil-backward-word-end" "evil-beginning-of-line" "evil-change-whole-line" "evil-command-window-ex" "evil-complete-previous" "evil-delete-whole-line" "evil-ex-search-forward" "evil-exit-visual-state" "evil-expat-colorscheme" "evil-forward-paragraph" "evil-mouse-drag-region" "evil-numbers/dec-at-pt" "evil-numbers/inc-at-pt" "evil-org-inner-element" "evil-org-inner-subtree" "evil-read-digraph-char" "evil-replace-backspace" "evil-split-next-buffer" "evil-split-prev-buffer" "evil-window-set-height" "facemenu-set-invisible" "facemenu-set-read-only" "facemenu-set-underline" "feedmail-run-the-queue" "ffap-dired-other-frame" "find-file-other-window" "find-function-at-point" "find-variable-at-point" "flyspell-delay-command" "forward-to-indentation" "git-timemachine-toggle" "gitlab-list-all-issues" "global-git-commit-mode" "global-magit-file-mode" "global-whitespace-mode" "gnus-agent-batch-fetch" "gnus-group-split-setup" "gnus-mailing-list-mode" "goto-address-prog-mode" "haskell-decl-scan-mode" "haskell-mode-find-uses" "haskell-mode-view-news" "haskell-process-reload" "haskell-session-change" "help-for-help-internal" "highlight-changes-mode" "ibuffer-diff-with-file" "ibuffer-filter-by-mode" "ibuffer-filter-by-name" "ibuffer-filter-disable" "ibuffer-invert-sorting" "ibuffer-jump-to-buffer" "ibuffer-mark-by-locked" "ibuffer-unmark-forward" "ido-dired-other-window" "ido-enter-magit-status" "ido-magic-forward-char" "image-backward-hscroll" "image-dired-delete-tag" "image-dired-minor-mode" "image-toggle-animation" "indent-for-tab-command" "isearch-forward-regexp" "isearch-forward-symbol" "isearch-repeat-forward" "iso-transl-ctl-x-8-map" "ivy-backward-kill-word" "ivy-next-line-and-call" "ivy-switch-buffer-kill" "kill-buffer-and-window" "kmacro-cycle-ring-next" "kmacro-name-last-macro" "kmacro-step-edit-macro" "lazy-highlight-cleanup" "list-dynamic-libraries" "list-load-path-shadows" "magit-am-apply-maildir" "magit-am-apply-patches" "magit-auto-revert-mode" "magit-blame-next-chunk" "magit-blame-visit-file" "magit-describe-section" "magit-diff-buffer-file" "magit-ediff-show-stash" "magit-edit-line-commit" "magit-jump-to-unstaged" "magit-kill-this-buffer" "magit-log-all-branches" "magit-mode-bury-buffer" "magit-reverse-in-index" "magit-revert-no-commit" "magit-section-backward" "magit-set-remote*fetch" "magit-stash-keep-index" "magit-submodule-update" "mail-add-payment-async" "mailcap-parse-mailcaps" "makefile-automake-mode" "markdown-backward-page" "markdown-exdent-region" "markdown-footnote-kill" "markdown-forward-block" "markdown-indent-region" "markdown-insert-header" "markdown-insert-italic" "markdown-previous-link" "markdown-remove-header" "markdown-show-children" "menu-bar-no-scroll-bar" "menu-bar-select-buffer" "message-change-subject" "message-display-abbrev" "message-fill-paragraph" "message-goto-signature" "message-insert-expires" "message-insert-headers" "mml-secure-encrypt-pgp" "mode-line-other-buffer" "mouse-drag-bottom-edge" "mouse-drag-header-line" "move-beginning-of-line" "next-multiframe-window" "ns-delete-working-text" "ns-do-emacs-info-panel" "ns-drag-n-drop-as-text" "ns-insert-working-text" "org-babel-tangle-clean" "org-backward-paragraph" "org-cycle-agenda-files" "org-date-from-calendar" "org-delete-indentation" "org-drag-line-backward" "org-feed-show-raw-feed" "org-find-entry-with-id" "org-find-file-at-mouse" "org-footnote-normalize" "org-insert-link-global" "org-speed-command-help" "org-store-agenda-views" "org-table-end-of-field" "org-table-eval-formula" "org-table-fedit-finish" "org-table-fedit-ref-up" "org-table-fedit-scroll" "org-table-insert-hline" "org-timestamp-down-day" "org-toggle-archive-tag" "org-toggle-fixed-width" "org-toggle-tags-groups" "org-update-all-dblocks" "outline-hide-sublevels" "outline-insert-heading" "outorg-edit-minor-mode" "outshine-insert-drawer" "outshine-open-at-point" "outshine-previous-link" "package-import-keyring" "package-menu-mode-menu" "pr-ps-file-up-ps-print" "pr-toggle-header-frame" "print-current-issue-id" "projectile-global-mode" "projectile-multi-occur" "projectile-run-project" "rcirc-track-minor-mode" "recover-session-finish" "rectangle-forward-char" "rectangle-number-lines" "repeat-complex-command" "rmail-expunge-and-save" "rmail-previous-message" "rmail-search-backwards" "rmail-summary-by-topic" "scroll-bar-scroll-down" "search-backward-regexp" "select-tags-table-mode" "select-tags-table-quit" "set-face-inverse-video" "set-justification-full" "set-justification-left" "set-justification-none" "set-locale-environment" "shell-backward-command" "smerge-diff-base-lower" "smerge-diff-base-other" "smerge-diff-base-upper" "smerge-diff-mine-other" "smerge-makeup-conflict" "smex-describe-function" "spam-report-deagentize" "table-fixed-width-mode" "table-recognize-region" "table-unrecognize-cell" "tags-reset-tags-tables" "tibetan-compose-buffer" "tibetan-compose-region" "toggle-frame-maximized" "turn-on-undo-tree-mode" "undo-tree-load-history" "undo-tree-save-history" "upcase-initials-region" "url-setup-privacy-info" "vc-dir-hide-up-to-date" "vdiff-magit-show-stash" "vdiff-refine-this-hunk" "vdiff-scroll-lock-mode" "view-external-packages" "view-file-other-window" "which-key-C-h-dispatch" "widget-move-and-invoke" "widget-narrow-to-field" "xref--xref-buffer-mode" "yas-expand-from-keymap" "yas/expand-from-keymap" "yas/visit-snippet-file" "5x5-crack-mutating-best" "Buffer-menu-multi-occur" "Buffer-menu-this-window" "abbrev-edit-save-buffer" "add-file-local-variable" "async-byte-compile-file" "atomic-chrome-edit-mode" "avy-goto-symbol-1-above" "avy-goto-symbol-1-below" "avy-org-refile-as-child" "backward-kill-paragraph" "backward-to-indentation" "bookmark-bmenu-1-window" "bookmark-bmenu-2-window" "bookmark-bmenu-relocate" "bug-reference-prog-mode" "cal-tex-cursor-week-iso" "calendar-backward-month" "calendar-goto-info-node" "calendar-iso-print-date" "calendar-set-date-style" "calendar-sunrise-sunset" "check-declare-directory" "checkdoc-current-buffer" "clojure-thread-last-all" "comint-dynamic-complete" "comint-interrupt-subjob" "comint-redirect-cleanup" "comint-set-process-mark" "comment-indent-new-line" "company-complete-common" "company-complete-number" "company-select-previous" "company-show-doc-buffer" "copy-from-above-command" "counsel-command-history" "crm-minibuffer-complete" "cua-rectangle-mark-mode" "customize-apropos-faces" "customize-save-variable" "default-indent-new-line" "delete-horizontal-space" "diff-kill-applied-hunks" "dired-async-do-hardlink" "dired-do-flagged-delete" "dired-do-isearch-regexp" "dired-do-symlink-regexp" "dired-flag-backup-files" "dired-flag-files-regexp" "dired-hide-details-mode" "dired-isearch-filenames" "dired-jump-other-window" "dired-mark-files-regexp" "dired-mark-subdir-files" "dired-subtree-beginning" "dockerfile-build-buffer" "dynamic-completion-mode" "ediff-merge-directories" "ediff-scroll-vertically" "ediff-toggle-autorefine" "ediff-toggle-multiframe" "ediff-up-meta-hierarchy" "emacs-lisp-byte-compile" "erc-capab-identify-mode" "erc-save-buffer-in-logs" "evgeni-counsel-git-grep" "evil-avy-goto-subword-0" "evil-avy-goto-subword-1" "evil-backward-paragraph" "evil-complete-next-line" "evil-end-of-visual-line" "evil-ex-global-inverted" "evil-ex-search-backward" "evil-ex-search-previous" "evil-find-char-backward" "evil-force-normal-state" "evil-forward-WORD-begin" "evil-forward-word-begin" "evil-inner-double-quote" "evil-inner-single-quote" "evil-jump-backward-swap" "evil-multiedit-ex-match" "evil-multiedit-operator" "evil-org-open-incognito" "evil-scroll-column-left" "evil-scroll-count-reset" "evil-scroll-line-to-top" "evil-visual-make-region" "exchange-point-and-mark" "facemenu-remove-special" "facemenu-set-background" "facemenu-set-foreground" "facemenu-set-intangible" "feedmail-queue-reminder" "ffap-dired-other-window" "follow-scroll-up-window" "font-lock-fontify-block" "git-commit-next-message" "git-commit-prev-message" "git-commit-save-message" "gitlab--shell-to-string" "gitlab-describe-project" "global-auto-revert-mode" "global-visual-line-mode" "gnus-group-split-update" "hashcash-insert-payment" "haskell-cabal-get-field" "haskell-process-do-info" "haskell-process-do-type" "haskell-process-restart" "help-at-pt-cancel-timer" "hindent-reformat-buffer" "hindent-reformat-region" "ibuffer-add-to-tmp-hide" "ibuffer-add-to-tmp-show" "ibuffer-do-sort-by-size" "ibuffer-mark-for-delete" "ibuffer-unmark-backward" "icalendar-export-region" "icalendar-import-buffer" "ido-bury-buffer-at-head" "ido-delete-file-at-head" "ido-enter-insert-buffer" "ido-enter-switch-buffer" "ido-find-alternate-file" "ido-find-file-read-only" "ido-kill-buffer-at-head" "ido-magic-backward-char" "ido-next-work-directory" "ido-prev-work-directory" "ido-restrict-to-matches" "imenu-add-menubar-index" "indent-new-comment-line" "inverse-add-mode-abbrev" "isearch-backward-regexp" "isearch-repeat-backward" "ivy-beginning-of-buffer" "ivy-occur-previous-line" "ivy-occur-revert-buffer" "ivy-restrict-to-matches" "ivy-scroll-down-command" "ivy-toggle-regexp-quote" "japanese-hankaku-region" "japanese-zenkaku-region" "kmacro-delete-ring-head" "magit-blame-cycle-style" "magit-cherry-pick-popup" "magit-cycle-pull.rebase" "magit-diff-less-context" "magit-diff-more-context" "magit-diff-working-tree" "magit-ediff-show-commit" "magit-ediff-show-staged" "magit-gitignore-locally" "magit-jump-to-untracked" "magit-log-refresh-popup" "magit-notes-merge-abort" "magit-patch-apply-popup" "magit-rebase-autosquash" "magit-remote-unset-head" "magit-run-git-gui-blame" "magit-run-gitk-branches" "magit-set-core.notesRef" "magit-show-refs-current" "magit-snapshot-worktree" "magit-stash-branch-here" "magit-worktree-checkout" "mailcap-parse-mimetypes" "markdown-backward-block" "markdown-demote-subtree" "markdown-fill-paragraph" "markdown-hide-sublevels" "markdown-kill-ring-save" "markdown-mark-paragraph" "markdown-narrow-to-page" "markdown-outdent-region" "markdown-table-move-row" "markdown-table-next-row" "menu-bar-kill-ring-save" "menu-bar-read-lispintro" "menu-find-file-existing" "message-goto-newsgroups" "message-insinuate-rmail" "message-mode-field-menu" "message-reduce-to-to-cc" "metamail-interpret-body" "mml-secure-message-sign" "mml-secure-sign-pgpauto" "mml-secure-sign-pgpmime" "mode-line-unbury-buffer" "mouse-choose-completion" "nameless-mode-from-hook" "newsticker-start-ticker" "org-babel-execute-maybe" "org-babel-exp-src-block" "org-babel-hash-at-point" "org-babel-remove-result" "org-cdlatex-math-modify" "org-create-math-formula" "org-element-cache-reset" "org-evaluate-time-range" "org-html-export-as-html" "org-html-export-to-html" "org-insert-todo-heading" "org-latex-export-to-pdf" "org-self-insert-command" "org-table-delete-column" "org-table-edit-formulas" "org-table-fedit-line-up" "org-table-insert-column" "org-table-move-row-down" "org-time-stamp-inactive" "org-toggle-link-display" "outline-headers-as-kill" "outline-move-subtree-up" "outline-toggle-children" "outshine-comment-region" "outshine-insert-heading" "outshine-toggle-comment" "package-menu-quick-help" "pr-ps-directory-preview" "projectile-kill-buffers" "projectile-project-info" "quickurl-browse-url-ask" "recentf-open-more-files" "rectangle-backward-char" "rectangle-previous-line" "replace-buffer-contents" "rmail-next-same-subject" "rmail-sort-by-recipient" "rmail-summary-by-labels" "rmail-summary-by-regexp" "save-buffers-kill-emacs" "search-unencodable-char" "set-justification-right" "shackle-trace-functions" "shell-command-on-region" "smartparens-global-mode" "smartparens-strict-mode" "smerge-diff-upper-lower" "sp-use-paredit-bindings" "split-window-vertically" "sql-product-interactive" "string-insert-rectangle" "strokes-describe-stroke" "table-insert-row-column" "table-unrecognize-table" "tabulated-list-col-sort" "temp-buffer-resize-mode" "timeclock-status-string" "toggle-auto-composition" "toggle-case-fold-search" "toggle-frame-fullscreen" "turn-on-gnus-dired-mode" "undo-tree-switch-branch" "unforward-rmail-message" "universal-argument-more" "vc-dir-unmark-all-files" "vc-find-conflicted-file" "vdiff-close-other-folds" "vdiff-magit-show-commit" "vdiff-toggle-hydra/body" "vdiff-toggle-whitespace" "viet-decode-viqr-buffer" "viet-decode-viqr-region" "viet-encode-viqr-buffer" "viet-encode-viqr-region" "view-buffer-other-frame" "view-echo-area-messages" "whitespace-newline-mode" "word-search-forward-lax" "xref-quit-and-goto-xref" "yas-activate-extra-mode" "yas-load-snippet-buffer" "yas/load-snippet-buffer" "Buffer-menu-mouse-select" "Buffer-menu-not-modified" "Buffer-menu-other-window" "Helper-describe-bindings" "Info-follow-nearest-node" "abbrev-edit-save-to-file" "align-newline-and-indent" "beginning-of-visual-line" "bookmark-insert-location" "browse-url-of-dired-file" "buffer-menu-other-window" "byte-recompile-directory" "calendar-bahai-goto-date" "calendar-cursor-holidays" "calendar-not-implemented" "canonically-space-region" "checkdoc-ispell-comments" "checkdoc-ispell-continue" "clipboard-kill-ring-save" "clojure-thread-first-all" "close-display-connection" "comint-goto-process-mark" "company-clang-set-prefix" "compile-mouse-goto-error" "completion-help-at-point" "compose-mail-other-frame" "counsel-find-file-extern" "custom-theme-visit-theme" "customize-apropos-groups" "debug-on-variable-change" "delete-completion-window" "describe-prefix-bindings" "describe-text-properties" "diary-bahai-insert-entry" "diary-insert-block-entry" "diff-hl-overlay-modified" "dired-build-subdir-alist" "dired-do-hardlink-regexp" "dired-flag-file-deletion" "dired-flag-garbage-files" "dired-get-file-for-visit" "ediff-dir-diff-copy-file" "ediff-jump-to-difference" "ediff-previous-meta-item" "ediff-toggle-ignore-case" "ediff-toggle-use-toolbar" "eldoc-in-minibuffer-mode" "emerge-merge-directories" "ethio-insert-ethio-space" "evgeni-beginning-of-line" "evgeni-dired-current-dir" "evgeni-move-text-line-up" "evil-avy-goto-char-timer" "evil-avy-goto-line-above" "evil-avy-goto-line-below" "evil-backward-WORD-begin" "evil-backward-word-begin" "evil-command-window-mode" "evil-exchange-cx-install" "evil-forward-section-end" "evil-multiedit-match-all" "evil-next-flyspell-error" "evil-prev-flyspell-error" "evil-previous-open-brace" "evil-previous-open-paren" "evil-scroll-column-right" "evil-search-word-forward" "evil-window-bottom-right" "execute-extended-command" "expand-jump-to-next-slot" "facemenu-set-bold-italic" "ff-mouse-find-other-file" "ffap-copy-string-as-kill" "file-cache-add-directory" "file-notify-handle-event" "find-library-other-frame" "flyspell-goto-next-error" "font-lock-fontify-buffer" "gitlab-list-all-projects" "gnus-bookmark-bmenu-list" "gnus-registry-initialize" "gnus-treat-from-gravatar" "gnus-treat-mail-gravatar" "goto-last-change-reverse" "haskell-cabal-visit-file" "haskell-indentation-mode" "haskell-interactive-kill" "haskell-mode-jump-to-def" "haskell-mode-jump-to-tag" "haskell-move-nested-left" "haskell-navigate-imports" "haskell-process-unignore" "helm-linum-relative-mode" "hi-lock-line-face-buffer" "hydra--negative-argument" "hydra-winner/winner-undo" "ibuffer-decompose-filter" "ibuffer-do-query-replace" "ibuffer-do-view-and-eval" "ibuffer-exchange-filters" "ibuffer-mark-old-buffers" "ibuffer-mouse-popup-menu" "ibuffer-pop-filter-group" "ibuffer-unmark-all-marks" "ibuffer-visit-tags-table" "ido-init-completion-maps" "image-toggle-hex-display" "interactive-haskell-mode" "isearch-highlight-regexp" "isearch-toggle-case-fold" "isearch-toggle-char-fold" "isearch-toggle-invisible" "isearch-yank-x-selection" "ispell-buffer-with-debug" "ispell-change-dictionary" "ivy-backward-delete-char" "ivy-next-history-element" "ivy-next-line-or-history" "ivy-occur-toggle-calling" "japanese-hiragana-region" "japanese-katakana-region" "kmacro-edit-macro-repeat" "kmacro-end-or-call-macro" "kmacro-view-macro-repeat" "magit-branch-or-checkout" "magit-copy-section-value" "magit-cycle-margin-style" "magit-diff-refresh-popup" "magit-fetch-all-no-prune" "magit-git-command-topdir" "magit-log-move-to-parent" "magit-merge-preview-mode" "magit-notes-merge-commit" "magit-pull-from-upstream" "magit-rebase-edit-commit" "magit-rebase-interactive" "magit-sequencer-continue" "magit-set-remote*pushurl" "magit-stash-format-patch" "magit-submodule-populate" "magit-submodule-register" "magit-subtree-add-commit" "magit-toggle-buffer-lock" "mail-abbrev-insert-alias" "map-query-replace-regexp" "mark-beginning-of-buffer" "markdown-complete-buffer" "markdown-complete-region" "markdown-edit-code-block" "markdown-footnote-return" "markdown-insert-footnote" "markdown-mark-text-block" "markdown-move-subtree-up" "markdown-narrow-to-block" "markdown-promote-subtree" "markdown-table-transpose" "menu-bar-left-scroll-bar" "message-check-recipients" "message-goto-followup-to" "message-insert-signature" "message-mail-other-frame" "message-mark-insert-file" "message-news-other-frame" "message-send-form-letter" "minibuffer-complete-word" "minibuffer-inactive-mode" "minibuffer-keyboard-quit" "mml-secure-encrypt-smime" "mouse-drag-vertical-line" "ns-open-file-select-line" "ns-open-file-using-panel" "org-activate-angle-links" "org-activate-plain-links" "org-agenda-file-to-front" "org-babel-execute-buffer" "org-babel-next-src-block" "org-babel-pop-to-session" "org-beamer-export-to-pdf" "org-calendar-goto-agenda" "org-change-tag-in-region" "org-delete-backward-char" "org-display-outline-path" "org-drag-element-forward" "org-duration-set-regexps" "org-edit-inline-src-code" "org-force-cycle-archived" "org-next-visible-heading" "org-open-at-point-global" "org-publish-current-file" "org-remove-inline-images" "org-save-all-org-buffers" "org-table-convert-region" "org-table-current-column" "org-table-fedit-ref-down" "org-table-fedit-ref-left" "org-table-hline-and-move" "org-table-previous-field" "org-table-show-reference" "org-toggle-inline-images" "org-toggle-sticky-agenda" "outline-previous-heading" "outshine-export-dispatch" "outshine-footnote-action" "outshine-speed-move-safe" "outshine-timer-set-timer" "outshine-toggle-checkbox" "package-menu-mark-delete" "package-menu-mark-unmark" "pkg-info-library-version" "pkg-info-package-version" "pp-macroexpand-last-sexp" "pr-ps-directory-ps-print" "pr-toggle-file-landscape" "previous-error-no-select" "previous-history-element" "print-current-project-id" "rmail-summary-by-senders" "scan-buf-previous-region" "scroll-other-window-down" "select-tags-table-select" "set-face-inverse-video-p" "set-justification-center" "set-language-environment" "smerge-combine-with-next" "smex-major-mode-commands" "swiper-all-query-replace" "table-unrecognize-region" "thumbs-dired-show-marked" "tibetan-decompose-buffer" "tibetan-decompose-region" "time-stamp-toggle-active" "todo-filtered-items-mode" "tramp-cleanup-connection" "tree-widget-button-click" "turn-on-haskell-doc-mode" "turn-on-smartparens-mode" "ucs-normalize-NFC-region" "ucs-normalize-NFD-region" "undo-tree-visualize-redo" "undo-tree-visualize-undo" "undo-tree-visualizer-set" "url-history-save-history" "vc-comment-to-change-log" "vc-default-check-headers" "vc-default-mark-resolved" "vc-revision-other-window" "view-buffer-other-window" "which-key-show-top-level" "whitespace-report-region" "widget-beginning-of-line" "word-search-backward-lax" "yas-skip-and-clear-field" "Buffer-menu-backup-unmark" "add-log-edit-next-comment" "add-log-edit-prev-comment" "antlr-show-makefile-rules" "atomic-chrome-start-httpd" "atomic-chrome-stop-server" "avy-kill-ring-save-region" "bookmark-set-no-overwrite" "c-guess-buffer-no-install" "c-guess-region-no-install" "calendar-bahai-print-date" "calendar-coptic-goto-date" "calendar-french-goto-date" "calendar-goto-day-of-year" "calendar-hebrew-goto-date" "calendar-julian-goto-date" "calendar-mayan-print-date" "checkdoc-package-keywords" "cl-old-struct-compat-mode" "company-eclim--candidates" "company-search-candidates" "company-search-other-char" "compilation-display-error" "compilation-previous-file" "completion-in-region-mode" "compose-mail-other-window" "counsel-describe-variable" "counsel-semantic-or-imenu" "customize-apropos-options" "customize-changed-options" "customize-save-customized" "delete-dir-local-variable" "delete-non-matching-lines" "delimit-columns-customize" "delimit-columns-rectangle" "diary-hebrew-insert-entry" "diary-insert-cyclic-entry" "diary-insert-weekly-entry" "diary-insert-yearly-entry" "dired-compare-directories" "dired-find-alternate-file" "dired-maybe-insert-subdir" "dired-single-buffer-mouse" "dired-single-magic-buffer" "dired-sort-toggle-or-edit" "display-line-numbers-mode" "ediff-directory-revisions" "ediff-help-for-quick-help" "ediff-merge-with-ancestor" "ediff-previous-difference" "ediff-scroll-horizontally" "ediff-toggle-regexp-match" "ediff-toggle-skip-similar" "ediff-toggle-wide-display" "edirs-merge-with-ancestor" "electric-pair-delete-pair" "electric-quote-local-mode" "erc-delete-dangerous-host" "ert-kill-all-test-buffers" "ethio-fidel-to-tex-buffer" "ethio-tex-to-fidel-buffer" "evgeni-entire-text-object" "evgeni-toggles-hydra/body" "evil-backward-section-end" "evil-copy-chars-from-line" "evil-delete-backward-char" "evil-delete-backward-word" "evil-ex-repeat-substitute" "evil-ex-set-initial-state" "evil-indent-plus-a-indent" "evil-indent-plus-i-indent" "evil-list-view-goto-entry" "evil-org-forward-sentence" "evil-paste-last-insertion" "evil-previous-visual-line" "evil-search-word-backward" "evil-window-move-far-left" "evil-window-move-very-top" "find-function-other-frame" "find-library-other-window" "find-variable-other-frame" "flyspell-pre-command-hook" "follow-scroll-down-window" "gitlab-issues-for-project" "global-diff-hl-amend-mode" "global-evil-surround-mode" "haskell-interactive-bring" "haskell-mode-show-type-at" "haskell-move-nested-right" "haskell-process-interrupt" "highlight-compare-buffers" "highlight-symbol-at-point" "hydra--universal-argument" "ibuffer-add-saved-filters" "ibuffer-do-isearch-regexp" "ibuffer-do-replace-regexp" "ibuffer-filter-by-content" "ibuffer-filter-by-size-gt" "ibuffer-filter-by-size-lt" "ibuffer-kill-filter-group" "ibuffer-mark-help-buffers" "ibuffer-mouse-toggle-mark" "ibuffer-recompile-formats" "ibuffer-yank-filter-group" "ido-delete-backward-updir" "ido-find-file-other-frame" "ido-forget-work-directory" "image-dired-display-thumb" "image-transform-set-scale" "inverse-add-global-abbrev" "isearch-describe-bindings" "isearch-yank-word-or-char" "json-pretty-print-ordered" "kmacro-end-and-call-macro" "log-edit-add-to-changelog" "log-edit-insert-changelog" "log-edit-insert-filenames" "log-edit-previous-comment" "magit-branch-and-checkout" "magit-branch-config-popup" "magit-branch-pull-request" "magit-browse-pull-request" "magit-cycle-branch*rebase" "magit-cycle-remote*tagOpt" "magit-ediff-show-unstaged" "magit-fetch-from-upstream" "magit-invoke-popup-action" "magit-invoke-popup-option" "magit-invoke-popup-switch" "magit-remote-config-popup" "magit-section-cycle-diffs" "magit-wip-after-save-mode" "mail-abbrev-end-of-buffer" "markdown-demote-list-item" "markdown-exdent-or-delete" "markdown-insert-list-item" "markdown-insert-wiki-link" "markdown-outline-previous" "markdown-table-delete-row" "markdown-table-insert-row" "markdown-table-sort-lines" "menu-bar-enable-clipboard" "menu-bar-right-scroll-bar" "message-beginning-of-line" "message-delete-not-region" "message-goto-distribution" "message-idna-to-ascii-rhs" "message-insert-newsgroups" "message-insert-wide-reply" "message-kill-to-signature" "message-mail-other-window" "message-news-other-window" "metamail-interpret-header" "minibuffer-force-complete" "mode-line-minor-mode-help" "mode-line-previous-buffer" "mode-line-toggle-modified" "mouse-popup-menubar-stuff" "ns-respond-to-change-font" "ns-write-file-using-panel" "org-ascii-export-as-ascii" "org-ascii-export-to-ascii" "org-babel-check-src-block" "org-babel-demarcate-block" "org-babel-execute-subtree" "org-babel-load-in-session" "org-babel-result-hide-all" "org-calendar-select-mouse" "org-clock-remove-overlays" "org-columns-insert-dblock" "org-convert-to-odd-levels" "org-create-customize-menu" "org-display-inline-images" "org-drag-element-backward" "org-edit-agenda-file-list" "org-element-update-syntax" "org-entities-create-table" "org-escape-code-in-region" "org-hugo-export-wim-to-md" "org-insert-columns-dblock" "org-latex-export-as-latex" "org-latex-export-to-latex" "org-md-export-as-markdown" "org-md-export-to-markdown" "org-occur-in-agenda-files" "org-open-link-from-string" "org-table-fedit-line-down" "org-table-fedit-ref-right" "org-table-paste-rectangle" "org-toggle-latex-fragment" "org-toggle-timestamp-type" "org-update-checkbox-count" "orgtbl-insert-radio-table" "outline-move-subtree-down" "outorg-which-active-modes" "outshine-agenda-add-files" "outshine-set-tags-command" "package-menu-hide-package" "package-menu-mark-install" "package-show-package-list" "pp-macroexpand-expression" "projectile-display-buffer" "projectile-find-file-dwim" "projectile-find-test-file" "projectile-replace-regexp" "quail-set-keyboard-layout" "query-replace-regexp-eval" "redirect-debugging-output" "reftex-index-phrases-mode" "reftex-isearch-minor-mode" "replace-buffer-in-windows" "rmail-output-body-to-file" "rmail-set-remote-password" "scroll-bar-toolkit-scroll" "shackle-untrace-functions" "smerge-popup-context-menu" "smtpmail-send-queued-mail" "spam-report-process-queue" "split-window-horizontally" "strokes-do-complex-stroke" "strokes-global-set-stroke" "strokes-load-user-strokes" "trace-function-background" "trace-function-foreground" "turn-off-smartparens-mode" "turn-on-haskell-decl-scan" "ucs-normalize-NFKC-region" "ucs-normalize-NFKD-region" "undigestify-rmail-message" "undo-tree-visualizer-mode" "undo-tree-visualizer-quit" "url-gateway-nslookup-host" "vc-comment-search-forward" "vc-comment-search-reverse" "vc-dir-previous-directory" "vc-git-stash-pop-at-point" "vc-revert-buffer-internal" "vdiff-hydra/vdiff-refresh" "whitespace-cleanup-region" "whitespace-toggle-options" "with-editor-export-editor" "with-editor-shell-command" "xwidget-webkit-browse-url" "yas-deactivate-extra-mode" "yas-direct-keymaps-reload" "yas/direct-keymaps-reload" "5x5-crack-mutating-current" "advertised-widget-backward" "atomic-chrome-start-server" "avy-goto-word-or-subword-1" "avy-org-goto-heading-timer" "bookmark-bmenu-this-window" "bookmark-jump-other-window" "browse-url-netscape-reload" "cal-menu-global-mouse-menu" "cal-tex-cursor-week-monday" "calendar-beginning-of-week" "calendar-beginning-of-year" "calendar-chinese-goto-date" "calendar-coptic-print-date" "calendar-count-days-region" "calendar-french-print-date" "calendar-hebrew-print-date" "calendar-islamic-goto-date" "calendar-julian-print-date" "calendar-persian-goto-date" "calendar-print-day-of-year" "calendar-print-other-dates" "comint-bol-or-process-mark" "comint-next-matching-input" "comint-show-maximum-output" "company-complete-selection" "company-search-delete-char" "compilation-previous-error" "copy-rectangle-to-register" "copyright-update-directory" "counsel-expression-history" "counsel-info-lookup-symbol" "counsel-library-candidates" "counsel-minibuffer-history" "delete-file-local-variable" "delete-minibuffer-contents" "delete-trailing-whitespace" "describe-buffer-case-table" "diary-chinese-insert-entry" "diary-insert-monthly-entry" "diary-islamic-insert-entry" "dired-advertised-find-file" "dired-flag-auto-save-files" "dired-sidebar-hide-sidebar" "dired-sidebar-show-sidebar" "dired-subtree-apply-filter" "dired-subtree-mark-subtree" "dired-subtree-next-sibling" "display-buffer-other-frame" "ebrowse-tags-loop-continue" "ebrowse-tags-query-replace" "edebug-eval-top-level-form" "ediff-collect-custom-diffs" "ediff-hide-marked-sessions" "ediff-toggle-narrow-region" "ediff-toggle-show-ancestor" "electric-indent-local-mode" "emerge-files-with-ancestor" "end-of-buffer-other-window" "epa-import-armor-in-region" "erc-nickserv-identify-mode" "ethio-fidel-to-sera-buffer" "ethio-fidel-to-sera-marker" "ethio-fidel-to-sera-region" "ethio-sera-to-fidel-buffer" "ethio-sera-to-fidel-marker" "ethio-sera-to-fidel-region" "evgeni-hydra-zoom/lambda-0" "evgeni-magit-file-checkout" "evgeni-move-text-line-down" "evgeni-start-ex-substitute" "evil-avy-goto-char-2-above" "evil-avy-goto-char-2-below" "evil-avy-goto-char-in-line" "evil-avy-goto-word-1-above" "evil-avy-goto-word-1-below" "evil-find-char-to-backward" "evil-forward-section-begin" "evil-middle-of-visual-line" "evil-org-a-greater-element" "evil-org-backward-sentence" "evil-org-beginning-of-line" "evil-replace-with-register" "evil-scroll-line-to-bottom" "evil-scroll-line-to-center" "evil-window-decrease-width" "evil-window-increase-width" "evil-window-move-far-right" "evil-window-rotate-upwards" "facemenu-remove-face-props" "ffap-read-only-other-frame" "fill-individual-paragraphs" "fill-nonuniform-paragraphs" "find-function-other-window" "find-variable-other-window" "flyspell-auto-correct-word" "flyspell-post-command-hook" "github-issue-browse-author" "gnus-cache-generate-active" "haskell-interactive-switch" "haskell-mode-generate-tags" "hi-lock-face-phrase-buffer" "horizontal-scroll-bar-mode" "ibuffer-do-rename-uniquely" "ibuffer-do-sort-by-recency" "ibuffer-do-toggle-modified" "ibuffer-filter-by-basename" "ibuffer-filter-by-filename" "ibuffer-filter-by-modified" "ibuffer-mark-dired-buffers" "ibuffer-mouse-visit-buffer" "ibuffer-save-filter-groups" "iconify-or-deiconify-frame" "ido-copy-current-file-name" "ido-find-file-other-window" "ido-merge-work-directories" "ido-toggle-virtual-buffers" "image-dired-display-thumbs" "info-xref-check-all-custom" "intero-highlight-uses-mode" "ivy-mouse-dispatching-done" "ivy-occur-delete-candidate" "ivy-occur-press-and-switch" "ivy-previous-line-and-call" "kmacro-cycle-ring-previous" "linum-relative-global-mode" "log-edit-beginning-of-line" "magit-add-change-log-entry" "magit-blame-previous-chunk" "magit-blame-read-only-mode" "magit-commit-instant-fixup" "magit-copy-buffer-revision" "magit-debug-git-executable" "magit-diff-default-context" "magit-find-git-config-file" "magit-log-trace-definition" "magit-pull-and-fetch-popup" "magit-pull-from-pushremote" "magit-rebase-onto-upstream" "magit-rebase-remove-commit" "magit-rebase-reword-commit" "magit-section-cycle-global" "magit-section-show-level-1" "magit-section-show-level-2" "magit-section-show-level-3" "magit-section-show-level-4" "magit-set-notes.displayRef" "magit-shell-command-topdir" "magit-submodule-unpopulate" "magit-wip-after-apply-mode" "mail-abbrev-complete-alias" "make-variable-buffer-local" "markdown-beginning-of-list" "markdown-blockquote-region" "markdown-complete-at-point" "markdown-end-of-text-block" "markdown-forward-paragraph" "markdown-insert-blockquote" "markdown-live-preview-mode" "markdown-move-list-item-up" "markdown-move-subtree-down" "markdown-outdent-or-delete" "markdown-promote-list-item" "markdown-reload-extensions" "markdown-table-move-column" "markdown-table-move-row-up" "markdown-toggle-url-hiding" "markdown-toggle-wiki-links" "menu-bar-no-window-divider" "message-add-archive-header" "message-caesar-buffer-body" "minibuffer-completion-help" "mml-secure-encrypt-pgpmime" "mml-secure-message-encrypt" "mode-line-toggle-read-only" "mouse-delete-other-windows" "mouse-drag-and-drop-region" "mouse-drag-top-left-corner" "move-text-default-bindings" "multi-isearch-files-regexp" "ns-drag-n-drop-other-frame" "occur-mode-goto-occurrence" "org-agenda-prepare-buffers" "org-babel-examplify-region" "org-babel-examplize-region" "org-babel-expand-src-block" "org-babel-initiate-session" "org-babel-shell-initialize" "org-beamer-export-as-latex" "org-beamer-export-to-latex" "org-beginning-of-item-list" "org-edit-latex-environment" "org-footnote-renumber-fn:N" "org-id-update-id-locations" "org-insert-todo-subheading" "org-list-insert-radio-list" "org-preview-latex-fragment" "org-revert-all-org-buffers" "org-set-property-and-value" "org-table-move-column-left" "org-texinfo-export-to-info" "org-toggle-pretty-entities" "orgtbl-self-insert-command" "outline-forward-same-level" "outorg-copy-edits-and-exit" "outshine-eval-lisp-subtree" "package-menu-backup-unmark" "package-menu-mark-upgrades" "package-menu-toggle-hiding" "paragraph-indent-text-mode" "previous-multiframe-window" "projectile-find-other-file" "projectile-regenerate-tags" "ps-print-buffer-with-faces" "ps-print-region-with-faces" "ps-spool-buffer-with-faces" "ps-spool-region-with-faces" "quail-show-keyboard-layout" "reset-language-environment" "rmail-beginning-of-message" "rmail-edit-current-message" "rmail-next-labeled-message" "save-buffers-kill-terminal" "scroll-bar-horizontal-drag" "set-face-background-pixmap" "set-keyboard-coding-system" "set-terminal-coding-system" "shadow-define-regexp-group" "shrink-window-horizontally" "skeleton-pair-insert-maybe" "smex-show-unbound-commands" "swiper-recenter-top-bottom" "toggle-save-place-globally" "toggle-text-mode-auto-fill" "undo-tree-visualizer-abort" "update-directory-autoloads" "vc-git-region-history-mode" "vc-git-stash-show-at-point" "which-key-show-full-keymap" "widget-browse-other-window" "window-toggle-side-windows" "Buffer-menu-isearch-buffers" "Info-copy-current-node-name" "apply-macro-to-region-lines" "async-bytecomp-package-mode" "beginning-of-defun-comments" "bookmark-bmenu-other-window" "cal-menu-context-mouse-menu" "cal-tex-cursor-filofax-week" "cal-tex-cursor-filofax-year" "calendar-beginning-of-month" "calendar-chinese-print-date" "calendar-ethiopic-goto-date" "calendar-islamic-print-date" "calendar-persian-print-date" "checkdoc-ispell-interactive" "comint-delchar-or-maybe-eof" "comment-or-uncomment-region" "counsel--info-lookup-symbol" "counsel-git-change-worktree" "counsel-git-grep-switch-cmd" "customize-face-other-window" "delete-whitespace-rectangle" "diff-ignore-whitespace-hunk" "dired-copy-filename-as-kill" "ediff-bury-dir-diffs-buffer" "ediff-meta-mark-equal-files" "ediff-unmark-all-for-hiding" "edit-tab-stops-note-changes" "enlarge-window-horizontally" "epa-decrypt-armor-in-region" "epa-file-name-regexp-update" "evgeni-projectile-find-file" "evil-backward-section-begin" "evil-collection-ediff-setup" "evil-command-window-execute" "evil-complete-previous-line" "evil-ex-search-word-forward" "evil-execute-in-emacs-state" "evil-exit-visual-and-repeat" "evil-forward-sentence-begin" "evil-magit-toggle-text-mode" "evil-operator-shortcut-mode" "evil-window-decrease-height" "evil-window-increase-height" "facemenu-set-face-from-menu" "ffap-read-only-other-window" "find-lisp-find-dired-filter" "global-evil-visualstar-mode" "gnus-mailing-list-insinuate" "gnus-registry-install-hooks" "gnus-sieve-article-add-rule" "gnus-treat-newsgroups-picon" "haskell-mode-stylish-buffer" "haskell-navigate-imports-go" "haskell-process-cabal-build" "highlight-compare-with-file" "ibuffer-clear-filter-groups" "ibuffer-do-toggle-read-only" "ibuffer-do-view-other-frame" "ibuffer-filter-by-directory" "ibuffer-filter-by-predicate" "ibuffer-filter-by-used-mode" "ibuffer-forward-next-marked" "ibuffer-mark-by-mode-regexp" "ibuffer-mark-by-name-regexp" "ibuffer-toggle-filter-group" "ibuffer-toggle-sorting-mode" "isearch-toggle-input-method" "ispell-comments-and-strings" "kmacro-call-ring-2nd-repeat" "magit-checkout-pull-request" "magit-commit-instant-squash" "magit-diff-trace-definition" "magit-diff-while-committing" "magit-fetch-from-pushremote" "magit-log-buffer-file-popup" "magit-log-half-commit-limit" "magit-remote-prune-refspecs" "magit-section-hide-children" "magit-section-show-children" "magit-section-show-headings" "magit-submodule-synchronize" "magit-toggle-margin-details" "magit-whitespace-disallowed" "mail-quote-printable-region" "markdown-backward-paragraph" "markdown-electric-backquote" "markdown-export-and-preview" "markdown-footnote-goto-text" "markdown-forward-same-level" "markdown-insert-header-dwim" "markdown-table-forward-cell" "message-fill-yanked-message" "message-simplify-recipients" "mml-secure-message-sign-pgp" "mouse-drag-top-right-corner" "nnml-generate-nov-databases" "ns-copy-including-secondary" "org-archive-subtree-default" "org-babel-describe-bindings" "org-babel-execute-src-block" "org-babel-goto-named-result" "org-babel-insert-header-arg" "org-babel-lob-execute-maybe" "org-babel-switch-to-session" "org-clock-update-time-maybe" "org-columns-remove-overlays" "org-edit-fixed-width-region" "org-edit-footnote-reference" "org-goto-local-auto-isearch" "org-hide-block-toggle-maybe" "org-icalendar-export-to-ics" "org-insert-last-stored-link" "org-md-convert-region-to-md" "org-publish-current-project" "org-redisplay-inline-images" "org-refile-goto-last-stored" "org-remove-occur-highlights" "org-setup-comments-handling" "org-table-fedit-lisp-indent" "org-table-fedit-scroll-down" "org-table-follow-field-mode" "org-table-move-column-right" "org-toggle-ordered-property" "org-tree-to-indirect-buffer" "org-unescape-code-in-region" "outline-backward-same-level" "outshine-speed-command-help" "outshine-toggle-archive-tag" "outshine-toggle-fixed-width" "package-install-from-buffer" "paragraph-indent-minor-mode" "process-menu-delete-process" "projectile-invalidate-cache" "projectile-switch-to-buffer" "quail-update-leim-list-file" "rmail-previous-same-subject" "rmail-sort-by-correspondent" "rmail-summary-by-recipients" "scroll-bar-set-window-start" "set-clipboard-coding-system" "set-file-name-coding-system" "set-selection-coding-system" "shadow-define-literal-group" "sp-use-smartparens-bindings" "swiper-toggle-face-matching" "table-split-cell-vertically" "timeclock-mode-line-display" "toggle-indicate-empty-lines" "turn-on-haskell-indentation" "unify-8859-on-decoding-mode" "unify-8859-on-encoding-mode" "url-cookie-setup-save-timer" "use-package-statistics-mode" "vc-dir-query-replace-regexp" "vc-git-stash-apply-at-point" "vdiff-hydra/vdiff-next-fold" "vdiff-hydra/vdiff-next-hunk" "vdiff-hydra/vdiff-open-fold" "vdiff-refine-all-hunks-word" "vdiff-refine-this-hunk-word" "vdiff-send-changes-and-step" "xref-show-location-at-point" "yas-expand-from-trigger-key" "yas/expand-from-trigger-key" "Buffer-menu-delete-backwards" "Buffer-menu-toggle-read-only" "Buffer-menu-visit-tags-table" "Info-goto-emacs-command-node" "Info-search-case-sensitively" "bookmark-bmenu-backup-unmark" "cal-tex-cursor-filofax-2week" "cal-tex-cursor-filofax-daily" "cal-tex-cursor-week2-summary" "calendar-ethiopic-print-date" "checkdoc-eval-current-buffer" "checkdoc-ispell-message-text" "checkdoc-message-interactive" "comint-append-output-to-file" "comint-get-next-from-history" "comint-redirect-send-command" "company-search-printing-char" "company-select-next-or-abort" "company-template-clear-field" "compilation-shell-minor-mode" "counsel-locate-action-extern" "counsel-org-agenda-headlines" "customize-group-other-window" "dired-do-async-shell-command" "dired-find-file-other-window" "dired-single-display-version" "dired-subtree-only-this-file" "dired-subtree-unmark-subtree" "ebrowse-electric-choose-tree" "ebrowse-tags-complete-symbol" "ebrowse-tags-find-definition" "ebrowse-tags-view-definition" "ediff-mark-for-hiding-at-pos" "electric-indent-just-newline" "emerge-buffers-with-ancestor" "evgeni-ex-delete-or-complete" "evil-avy-goto-symbol-1-above" "evil-avy-goto-symbol-1-below" "evil-backward-sentence-begin" "evil-change-to-initial-state" "evil-collection-ediff-revert" "evil-ex-delete-backward-char" "evil-ex-search-word-backward" "evil-execute-in-normal-state" "evil-indent-plus-a-indent-up" "evil-indent-plus-i-indent-up" "evil-save-modified-and-close" "evil-visual-exchange-corners" "evil-window-move-very-bottom" "evil-window-rotate-downwards" "expand-jump-to-previous-slot" "find-file-literally-at-point" "flyspell-deplacement-command" "forms-find-file-other-window" "git-commit-insert-issue-mode" "global-auto-composition-mode" "global-prettify-symbols-mode" "gnus-fetch-group-other-frame" "haskell-kill-session-process" "haskell-process-cabal-macros" "hi-lock-face-symbol-at-point" "ibuffer-delete-saved-filters" "ibuffer-do-sort-by-mode-name" "ibuffer-do-view-horizontally" "ibuffer-forward-filter-group" "ibuffer-jump-to-filter-group" "ibuffer-mark-special-buffers" "ibuffer-mark-unsaved-buffers" "ibuffer-mouse-filter-by-mode" "ibuffer-repair-saved-filters" "image-transform-fit-to-width" "image-transform-set-rotation" "isearch-query-replace-regexp" "ivy-previous-history-element" "ivy-previous-line-or-history" "log-edit-insert-cvs-template" "magit-blame-visit-other-file" "magit-diff-show-or-scroll-up" "magit-diff-switch-range-type" "magit-do-async-shell-command" "magit-find-file-other-window" "magit-rebase-onto-pushremote" "magit-wip-before-change-mode" "magit-wip-commit-buffer-file" "markdown-backward-same-level" "markdown-insert-gfm-checkbox" "markdown-insert-header-atx-1" "markdown-insert-header-atx-2" "markdown-insert-header-atx-3" "markdown-insert-header-atx-4" "markdown-insert-header-atx-5" "markdown-insert-header-atx-6" "markdown-kill-thing-at-point" "markdown-live-preview-export" "markdown-move-list-item-down" "markdown-reference-goto-link" "markdown-table-backward-cell" "markdown-table-delete-column" "markdown-table-insert-column" "markdown-table-move-row-down" "markdown-toggle-gfm-checkbox" "message-mark-inserted-region" "message-newline-and-reformat" "minibuffer-complete-and-exit" "move-past-close-and-reindent" "multi-isearch-buffers-regexp" "next-error-follow-minor-mode" "next-line-or-history-element" "ns-store-cut-buffer-internal" "org-babel-exp-process-buffer" "org-babel-hide-result-toggle" "org-babel-previous-src-block" "org-babel-tangle-jump-to-org" "org-cdlatex-underscore-caret" "org-decrease-number-at-point" "org-delete-property-globally" "org-footnote-goto-definition" "org-increase-number-at-point" "org-previous-visible-heading" "org-table-beginning-of-field" "org-table-calc-current-TBLFM" "outline-next-visible-heading" "outshine-agenda-remove-files" "outshine-force-cycle-comment" "outshine-latex-insert-header" "outshine-self-insert-command" "outshine-time-stamp-inactive" "package-menu-view-commentary" "pr-despool-using-ghostscript" "pr-ps-file-using-ghostscript" "pr-ps-mode-using-ghostscript" "projectile-add-known-project" "projectile-configure-project" "projectile-dired-other-frame" "restclient-http-send-current" "rmail-next-undeleted-message" "show-smartparens-global-mode" "switch-to-buffer-other-frame" "toggle-horizontal-scroll-bar" "toggle-uniquify-buffer-names" "turn-on-evil-visualstar-mode" "ucs-normalize-HFS-NFC-region" "ucs-normalize-HFS-NFD-region" "url-history-setup-save-timer" "use-package-reset-statistics" "vc-git-log-edit-toggle-amend" "vc-git-stash-delete-at-point" "vdiff-hydra/vdiff-close-fold" "wdired-change-to-wdired-mode" "which-key-show-standard-help" "windmove-default-keybindings" "with-editor-export-hg-editor" "Buffer-menu-toggle-files-only" "Buffer-menu-view-other-window" "ansi-color-for-comint-mode-on" "auth-source-forget-all-cached" "autothemer-generate-templates" "avy-kill-ring-save-whole-line" "backward-delete-char-untabify" "binhex-decode-region-external" "binhex-decode-region-internal" "bookmark-edit-annotation-mode" "cal-tex-cursor-year-landscape" "calendar-mayan-next-haab-date" "calendar-sunrise-sunset-month" "comint-forward-matching-input" "company-search-repeat-forward" "counsel-shell-command-history" "customize-option-other-window" "delete-other-windows-internal" "describe-language-environment" "describe-personal-keybindings" "dired-do-query-replace-regexp" "dired-sidebar-jump-to-sidebar" "dns-mode-soa-increment-serial" "ebrowse-tags-find-declaration" "ebrowse-tags-view-declaration" "ediff-make-or-kill-fine-diffs" "ethio-input-special-character" "evil-beginning-of-visual-line" "evil-change-to-previous-state" "evil-multiedit-match-and-next" "evil-multiedit-match-and-prev" "evil-org-delete-backward-char" "evil-org-open-links-incognito" "evil-quit-all-with-error-code" "evil-repeat-find-char-reverse" "exec-path-from-shell-copy-env" "file-cache-add-directory-list" "git-timemachine-switch-branch" "global-highlight-changes-mode" "gnus-outlook-deuglify-article" "hashcash-insert-payment-async" "haskell-session-change-target" "highlight-changes-next-change" "hindent-reformat-decl-or-fill" "htmlfontify-copy-and-link-dir" "ibuffer-backward-filter-group" "ibuffer-backwards-next-marked" "ibuffer-copy-filename-as-kill" "ibuffer-do-shell-command-file" "ibuffer-do-shell-command-pipe" "ibuffer-do-sort-by-alphabetic" "ibuffer-do-sort-by-major-mode" "ibuffer-mark-modified-buffers" "ibuffer-visit-buffer-1-window" "ido-switch-buffer-other-frame" "ido-undo-merge-work-directory" "ido-wide-find-file-or-pop-dir" "iedit-mode-toggle-on-function" "image-dired-mark-tagged-files" "image-dired-show-all-from-dir" "image-transform-fit-to-height" "indian-2-column-to-ucs-region" "isearch-toggle-lax-whitespace" "ispell-hunspell-add-multi-dic" "ivy-rotate-preferred-builders" "magit-cycle-branch*pushRemote" "magit-diff-toggle-file-filter" "magit-diff-toggle-refine-hunk" "magit-ediff-show-working-tree" "magit-edit-branch*description" "magit-log-double-commit-limit" "magit-log-toggle-commit-limit" "magit-save-repository-buffers" "magit-section-forward-sibling" "magit-section-toggle-children" "magit-set-branch*merge/remote" "mail-unquote-printable-region" "markdown-cleanup-list-numbers" "markdown-follow-link-at-point" "markdown-next-visible-heading" "markdown-remove-inline-images" "markdown-table-convert-region" "markdown-toggle-inline-images" "markdown-toggle-markup-hiding" "menu-bar-right-window-divider" "message-goto-mail-followup-to" "message-insert-importance-low" "mml-secure-message-sign-smime" "mouse-drag-bottom-left-corner" "mouse-split-window-vertically" "network-connection-to-service" "next-complete-history-element" "next-matching-history-element" "nnfolder-generate-active-file" "nonincremental-search-forward" "occur-mode-display-occurrence" "org-babel-goto-src-block-head" "org-babel-view-src-block-info" "org-beamer-select-environment" "org-compute-property-at-point" "org-convert-to-oddeven-levels" "org-html-htmlize-generate-css" "org-table-overlay-coordinates" "org-table-rotate-recalc-marks" "org-texinfo-export-to-texinfo" "org-update-statistics-cookies" "outline-subheadings-visible-p" "outorg-save-edits-to-tmp-file" "package-menu-describe-package" "pcomplete-expand-and-complete" "project-or-external-find-file" "projectile-cache-current-file" "projectile-dired-other-window" "projectile-skel-variable-cons" "recentf-open-most-recent-file" "rfc2047-encode-message-header" "set-buffer-file-coding-system" "switch-to-buffer-other-window" "table-split-cell-horizontally" "tramp-cleanup-all-connections" "tramp-cleanup-this-connection" "turn-off-evil-visualstar-mode" "turn-on-show-smartparens-mode" "undo-tree-visualize-redo-to-x" "undo-tree-visualize-undo-to-x" "vc-dir-find-file-other-window" "vdiff-magit-show-working-tree" "vdiff-refine-all-hunks-symbol" "vdiff-refine-this-hunk-symbol" "with-editor-export-git-editor" "xref-query-replace-in-results" "Buffer-menu-unmark-all-buffers" "Info-mouse-follow-nearest-node" "ansi-color-for-comint-mode-off" "atomic-chrome-send-buffer-text" "bookmark-bmenu-edit-annotation" "bookmark-bmenu-show-annotation" "cal-tex-cursor-month-landscape" "calendar-astro-goto-day-number" "calendar-hebrew-list-yahrzeits" "calendar-mayan-next-round-date" "calendar-scroll-toolkit-scroll" "checkdoc-ispell-current-buffer" "clojure-let-forward-slurp-sexp" "comint-backward-matching-input" "comint-dynamic-list-input-ring" "comint-previous-matching-input" "company-search-repeat-backward" "company-template-forward-field" "company-template-move-to-first" "compilation-set-skip-threshold" "copy-dir-locals-to-file-locals" "copy-file-locals-to-dir-locals" "counsel-git-grep-query-replace" "crm-minibuffer-completion-help" "describe-current-coding-system" "describe-current-display-table" "diary-insert-anniversary-entry" "diary-view-other-diary-entries" "dired-isearch-filenames-regexp" "dired-subtree-previous-sibling" "ebrowse-back-in-position-stack" "ebrowse-electric-position-menu" "ebrowse-tags-search-member-use" "ediff-inferior-compare-regions" "ediff-toggle-show-clashes-only" "ediff-unmark-all-for-operation" "elisp-last-sexp-toggle-display" "emerge-revisions-with-ancestor" "epa-verify-cleartext-in-region" "evgeni-vdiff-close-if-readonly" "evil-next-line-first-non-blank" "evil-org-inner-greater-element" "evil-scroll-bottom-line-to-top" "evil-scroll-top-line-to-bottom" "file-cache-minibuffer-complete" "gitlab-list-all-project-issues" "global-atomic-chrome-edit-mode" "global-whitespace-newline-mode" "haskell-process-load-or-reload" "highlight-changes-rotate-faces" "highlight-changes-visible-mode" "ibuffer-decompose-filter-group" "ibuffer-filter-by-derived-mode" "ibuffer-filter-by-starred-name" "ibuffer-mark-by-content-regexp" "ibuffer-mark-read-only-buffers" "ido-delete-backward-word-updir" "ido-display-buffer-other-frame" "ido-switch-buffer-other-window" "isearch-help-for-help-internal" "isearch-lazy-highlight-cleanup" "ivy-switch-buffer-other-window" "ivy-wgrep-change-to-wgrep-mode" "log-edit-comment-to-change-log" "magit-cycle-remote.pushDefault" "magit-diff-show-or-scroll-down" "magit-diff-visit-file-worktree" "magit-jump-to-diffstat-or-diff" "magit-push-current-to-upstream" "magit-section-backward-sibling" "magit-section-show-level-1-all" "magit-section-show-level-2-all" "magit-section-show-level-3-all" "magit-section-show-level-4-all" "magit-set-global-core.notesRef" "markdown-display-inline-images" "markdown-follow-thing-at-point" "markdown-insert-gfm-code-block" "markdown-insert-strike-through" "menu-bar-bottom-window-divider" "message-cross-post-followup-to" "message-insert-importance-high" "minibuffer-depth-indicate-mode" "minor-mode-menu-from-indicator" "mml-secure-message-encrypt-pgp" "mouse-drag-bottom-right-corner" "mouse-secondary-save-then-kill" "move-to-window-line-top-bottom" "nndiary-generate-nov-databases" "nonincremental-search-backward" "normal-erase-is-backspace-mode" "org-advertized-archive-subtree" "org-agenda-list-stuck-projects" "org-archive-to-archive-sibling" "org-babel-goto-named-src-block" "org-babel-pop-to-session-maybe" "org-babel-remove-inline-result" "org-cdlatex-environment-indent" "org-forward-heading-same-level" "org-kill-note-or-show-branches" "org-occur-link-in-agenda-files" "org-odt-export-as-odf-and-open" "org-require-autoloaded-modules" "org-table-create-with-table.el" "org-toggle-time-stamp-overlays" "org-update-radio-target-regexp" "outshine-toggle-silent-cycling" "package-list-packages-no-fetch" "pr-ps-buffer-using-ghostscript" "pr-ps-region-using-ghostscript" "projectile-run-command-in-root" "projectile-switch-open-project" "quoted-printable-decode-region" "rmail-previous-labeled-message" "shell-command-with-editor-mode" "shell-dynamic-complete-command" "smartparens-global-strict-mode" "strokes-compose-complex-stroke" "timeclock-when-to-leave-string" "turn-off-show-smartparens-mode" "undo-tree-visualizer-mouse-set" "undo-tree-visualizer-scroll-up" "vc-dir-kill-dir-status-process" "vc-git-log-edit-toggle-signoff" "vdiff-hydra/vdiff-save-buffers" "vdiff-hydra/vdiff-send-changes" "vdiff-receive-changes-and-step" "which-key-show-next-page-cycle" "widget-key-sequence-read-event" "yas-describe-table-by-namehash" "yas-next-field-or-maybe-expand" "yas/next-field-or-maybe-expand" "zerodark-setup-modeline-format" "Buffer-menu-switch-other-window" "bookmark-bmenu-delete-backwards" "bookmark-bmenu-toggle-filenames" "bookmark-send-edited-annotation" "calendar-astro-print-day-number" "cancel-debug-on-variable-change" "clojure-let-backward-slurp-sexp" "comint-history-isearch-backward" "comint-insert-previous-argument" "company-search-toggle-filtering" "compilation-next-error-function" "customize-variable-other-window" "delete-other-windows-vertically" "describe-minor-mode-from-symbol" "diary-bahai-insert-yearly-entry" "diff-delete-trailing-whitespace" "dired-single-toggle-buffer-name" "ediff-mark-for-operation-at-pos" "ediff-merge-directory-revisions" "ediff-merge-files-with-ancestor" "evgeni-prev-or-move-end-of-line" "evil-avy-goto-word-or-subword-1" "evil-collection-ediff-scroll-up" "exec-path-from-shell-initialize" "find-file-read-only-other-frame" "frame-configuration-to-register" "gitlab-show-project-description" "haskell-interactive-mode-return" "haskell-mode-jump-to-def-or-tag" "haskell-navigate-imports-return" "haskell-process-minimal-imports" "highlight-lines-matching-regexp" "ibuffer-copy-buffername-as-kill" "ibuffer-do-query-replace-regexp" "ibuffer-filter-by-visiting-file" "ibuffer-filters-to-filter-group" "ibuffer-switch-to-saved-filters" "ido-wide-find-dir-or-delete-dir" "image-dired-dired-comment-files" "image-dired-dired-display-image" "indent-rigidly-left-to-tab-stop" "isearch-forward-exit-minibuffer" "isearch-forward-symbol-at-point" "isearch-reverse-exit-minibuffer" "isearch-yank-char-in-minibuffer" "kmacro-end-or-call-macro-repeat" "log-edit-comment-search-forward" "log-edit-insert-cvs-rcstemplate" "magit-log-set-default-arguments" "magit-wip-after-save-local-mode" "mail-decode-encoded-word-region" "mail-encode-encoded-word-buffer" "markdown-insert-header-setext-1" "markdown-insert-header-setext-2" "markdown-live-preview-re-export" "markdown-table-move-column-left" "message-toggle-image-thumbnails" "mml-secure-message-sign-encrypt" "mml-secure-message-sign-pgpauto" "mml-secure-message-sign-pgpmime" "mouse-split-window-horizontally" "multi-occur-in-matching-buffers" "org-agenda-set-restriction-lock" "org-babel-load-in-session-maybe" "org-babel-open-src-block-result" "org-backward-heading-same-level" "org-bullets-set-point-and-cycle" "org-html-convert-region-to-html" "org-property-next-allowed-value" "org-src-associate-babel-session" "org-table-fedit-toggle-ref-type" "org-table-iterate-buffer-tables" "outshine-imenu-with-navi-regexp" "outshine-insert-comment-subtree" "outshine-set-property-and-value" "project-or-external-find-regexp" "projectile-clear-known-projects" "projectile-find-dir-other-frame" "projectile-purge-dir-from-cache" "projectile-remove-known-project" "projectile-save-project-buffers" "recentf-open-most-recent-file-0" "recentf-open-most-recent-file-1" "recentf-open-most-recent-file-2" "recentf-open-most-recent-file-3" "recentf-open-most-recent-file-4" "recentf-open-most-recent-file-5" "recentf-open-most-recent-file-6" "recentf-open-most-recent-file-7" "recentf-open-most-recent-file-8" "recentf-open-most-recent-file-9" "repeat-matching-complex-command" "rmail-undelete-previous-message" "shell-copy-environment-variable" "shell-dynamic-complete-filename" "toggle-menu-bar-mode-from-frame" "toggle-tool-bar-mode-from-frame" "turn-on-smartparens-strict-mode" "uudecode-decode-region-external" "uudecode-decode-region-internal" "vdiff-hydra/vdiff-previous-fold" "vdiff-hydra/vdiff-previous-hunk" "vdiff-hydra/vdiff-quit-and-exit" "vdiff-hydra/vdiff-switch-buffer" "with-editor-async-shell-command" "Info-goto-emacs-key-command-node" "beginning-of-buffer-other-window" "bookmark-bmenu-execute-deletions" "calendar-exchange-point-and-mark" "calendar-mayan-next-tzolkin-date" "comint-dynamic-complete-filename" "company-complete-common-or-cycle" "company-select-previous-or-abort" "crm-minibuffer-complete-and-exit" "diary-bahai-insert-monthly-entry" "diary-hebrew-insert-yearly-entry" "diff-hl-flydiff-buffer-with-head" "dired-do-find-regexp-and-replace" "dockerfile-build-no-cache-buffer" "ediff-toggle-filename-truncation" "emacs-lisp-byte-compile-and-load" "evil-ex-repeat-global-substitute" "evil-magit-maybe-deactivate-mark" "evil-next-line-1-first-non-blank" "ffap-alternate-file-other-window" "find-alternate-file-other-window" "find-file-read-only-other-window" "find-function-on-key-other-frame" "global-display-line-numbers-mode" "global-whitespace-toggle-options" "gnus-insert-random-x-face-header" "haskell-hoogle-lookup-from-local" "help-with-tutorial-spec-language" "ibuffer-filter-by-file-extension" "ibuffer-mark-by-file-name-regexp" "ibuffer-mark-dissociated-buffers" "ibuffer-visit-buffer-other-frame" "indent-rigidly-right-to-tab-stop" "json-pretty-print-buffer-ordered" "log-edit-comment-search-backward" "log-edit-insert-message-template" "magit-diff-set-default-arguments" "magit-log-save-default-arguments" "magit-push-current-to-pushremote" "magit-refs-set-show-commit-count" "markdown-beginning-of-text-block" "markdown-insert-inline-link-dwim" "markdown-outline-next-same-level" "markdown-table-move-column-right" "menu-bar-showhide-fringe-ind-box" "message-remove-blank-cited-lines" "minibuffer-electric-default-mode" "mml-secure-message-encrypt-smime" "nonincremental-re-search-forward" "org-babel-expand-src-block-maybe" "org-insert-heading-after-current" "org-reset-checkbox-state-subtree" "org-table-maybe-recalculate-line" "org-timer-change-times-in-region" "outline-previous-visible-heading" "outshine-comment-subtree-content" "outshine-insert-last-stored-link" "previous-line-or-history-element" "projectile-browse-dirty-projects" "projectile-find-dir-other-window" "projectile-find-file-other-frame" "projectile-purge-file-from-cache" "reindent-then-newline-and-indent" "restclient-http-send-current-raw" "revert-buffer-with-coding-system" "rmail-previous-undeleted-message" "set-buffer-process-coding-system" "set-next-selection-coding-system" "timeclock-workday-elapsed-string" "turn-off-smartparens-strict-mode" "undo-tree-save-state-to-register" "undo-tree-visualizer-scroll-down" "undo-tree-visualizer-scroll-left" "undo-tree-visualizer-select-left" "undo-tree-visualizer-select-next" "undo-tree-visualizer-toggle-diff" "universal-coding-system-argument" "use-package-jump-to-package-form" "vdiff-hydra/vdiff-open-all-folds" "vdiff-remove-refinements-in-hunk" "which-key-show-minor-mode-keymap" "window-configuration-to-register" "add-change-log-entry-other-window" "add-file-local-variable-prop-line" "ansi-color-for-comint-mode-filter" "browse-url-default-macosx-browser" "calendar-mayan-previous-haab-date" "calendar-mouse-view-diary-entries" "calendar-scroll-left-three-months" "clojure-convert-collection-to-map" "clojure-convert-collection-to-set" "company-indent-or-complete-common" "diary-chinese-insert-yearly-entry" "diary-hebrew-insert-monthly-entry" "diary-islamic-insert-yearly-entry" "dired-mouse-find-file-other-frame" "dired-subtree-only-this-directory" "ebrowse-forward-in-position-stack" "ediff-jump-to-difference-at-point" "ediff-merge-buffers-with-ancestor" "ediff-toggle-skip-changed-regions" "electric-newline-and-maybe-indent" "evgeni-prev-or-prev-and-backspace" "evil-collection-describe-bindings" "evil-collection-diff-toggle-setup" "evil-collection-ediff-scroll-down" "evil-collection-ediff-scroll-left" "evil-collection-ediff-scroll-up-1" "evil-find-file-at-point-with-line" "evil-indent-plus-a-indent-up-down" "evil-indent-plus-i-indent-up-down" "evil-magit-toggle-text-minor-mode" "evil-multiedit-toggle-marker-here" "evil-update-insert-state-bindings" "feedmail-run-the-queue-no-prompts" "find-function-on-key-other-window" "gnus-article-outlook-unwrap-lines" "gnus-cache-generate-nov-databases" "haskell-process-reload-devel-main" "highlight-changes-previous-change" "hydra-winner/winner-redo-and-exit" "ibuffer-do-kill-on-deletion-marks" "ibuffer-mark-for-delete-backwards" "ibuffer-mouse-toggle-filter-group" "ibuffer-set-filter-groups-by-mode" "ibuffer-visit-buffer-other-window" "image-dired-display-thumbs-append" "image-dired-jump-thumbnail-buffer" "magit-cycle-branch*autoSetupMerge" "magit-diff-save-default-arguments" "magit-popup-set-default-arguments" "magit-set-global-notes.displayRef" "markdown-previous-visible-heading" "menu-bar-showhide-fringe-ind-left" "menu-bar-showhide-fringe-ind-none" "menu-bar-window-divider-customize" "nonincremental-re-search-backward" "org-babel-execute-src-block-maybe" "org-clone-subtree-with-time-shift" "org-icalendar-export-agenda-files" "org-latex-convert-region-to-latex" "org-table-toggle-formula-debugger" "package-install-selected-packages" "pkg-info-defining-library-version" "pkg-info-library-original-version" "pr-ps-directory-using-ghostscript" "previous-complete-history-element" "previous-matching-history-element" "profiler-find-profile-other-frame" "projectile-cleanup-known-projects" "projectile-find-file-in-directory" "projectile-find-file-other-window" "rectangle-exchange-point-and-mark" "scroll-bar-maybe-set-window-start" "undo-tree-visualizer-mouse-select" "undo-tree-visualizer-scroll-right" "undo-tree-visualizer-select-right" "vdiff-hydra/vdiff-close-all-folds" "vdiff-hydra/vdiff-receive-changes" "which-key-setup-side-window-right" "which-key-show-next-page-no-cycle" "xref-find-definitions-other-frame" "yas-load-snippet-buffer-and-close" "yas-skip-and-clear-or-delete-char" "yas/skip-and-clear-or-delete-char" "Buffer-menu-isearch-buffers-regexp" "atomic-chrome-close-current-buffer" "bookmark-bmenu-switch-other-window" "browse-url-default-windows-browser" "calendar-mayan-previous-round-date" "calendar-scroll-right-three-months" "clojure-convert-collection-to-list" "clone-indirect-buffer-other-window" "color-theme-sanityinc-tomorrow-day" "comint-redirect-remove-redirection" "comint-replace-by-expanded-history" "describe-minor-mode-from-indicator" "diary-chinese-insert-monthly-entry" "diary-islamic-insert-monthly-entry" "dired-mark-files-containing-regexp" "dired-mouse-find-file-other-window" "ediff-restore-diff-in-merge-buffer" "ediff-show-meta-buff-from-registry" "edir-merge-revisions-with-ancestor" "evil-collection-ediff-scroll-right" "evil-command-window-search-forward" "evil-delete-backward-char-and-join" "evil-multiedit-insert-state-escape" "evil-previous-line-first-non-blank" "evil-search-unbounded-word-forward" "evil-switch-to-windows-last-buffer" "flyspell-correct-word-before-point" "gitlab-project-clone-button-action" "hi-lock-write-interactive-patterns" "highlight-changes-remove-highlight" "ibuffer-delete-saved-filter-groups" "ibuffer-filter-by-projectile-files" "ibuffer-interactive-filter-by-mode" "image-dired-dired-display-external" "indent-relative-first-indent-point" "ispell-complete-word-interior-frag" "magit-blame-next-chunk-same-commit" "magit-cycle-branch*autoSetupRebase" "magit-diff-visit-file-other-window" "magit-jump-to-unpushed-to-upstream" "magit-popup-save-default-arguments" "markdown-follow-wiki-link-at-point" "markdown-fontify-buffer-wiki-links" "markdown-insert-header-setext-dwim" "markdown-reference-goto-definition" "menu-bar-showhide-fringe-ind-mixed" "menu-bar-showhide-fringe-ind-right" "minibuffer-force-complete-and-exit" "mml-secure-message-encrypt-pgpauto" "mml-secure-message-encrypt-pgpmime" "ns-drag-n-drop-as-text-other-frame" "org-babel-hide-result-toggle-maybe" "org-blackfriday-export-as-markdown" "org-blackfriday-export-to-markdown" "org-export-insert-default-template" "org-icalendar-combine-agenda-files" "org-insert-heading-respect-content" "org-table-fedit-toggle-coordinates" "org-table-transpose-table-at-point" "outorg-insert-export-template-file" "outshine-hide-hidden-lines-cookies" "outshine-show-hidden-lines-cookies" "profiler-find-profile-other-window" "save-place-forget-unreadable-files" "standard-display-cyrillic-translit" "timeclock-workday-remaining-string" "toggle-enable-multibyte-characters" "vdiff-hydra/vdiff-refine-all-hunks" "vdiff-hydra/vdiff-refine-this-hunk" "which-key-setup-side-window-bottom" "which-key-show-previous-page-cycle" "xref-find-definitions-other-window" "bookmark-bmenu-show-all-annotations" "calendar-mayan-goto-long-count-date" "checkdoc-ispell-message-interactive" "color-theme-sanityinc-tomorrow-blue" "comint-replace-by-expanded-filename" "describe-specified-language-support" "ediff-merge-revisions-with-ancestor" "evgeni-hydra-zoom/text-scale-adjust" "evil-collection-ediff-scroll-down-1" "evil-command-window-search-backward" "evil-first-non-blank-of-visual-line" "evil-search-unbounded-word-backward" "file-cache-add-directory-using-find" "find-lisp-find-dired-subdirectories" "flyspell-auto-correct-previous-hook" "flyspell-auto-correct-previous-word" "gitlab-list-all-project-issue-notes" "ibuffer-do-sort-by-filename/process" "ibuffer-filter-chosen-by-completion" "ido-find-file-read-only-other-frame" "image-dired-setup-dired-keybindings" "js2-highlight-unused-variables-mode" "markdown-check-change-for-wiki-link" "markdown-insert-reference-link-dwim" "message-insert-or-toggle-importance" "org-babel-remove-result-one-or-many" "org-property-previous-allowed-value" "org-speedbar-set-agenda-restriction" "org-table-recalculate-buffer-tables" "shell-replace-by-expanded-directory" "shrink-window-if-larger-than-buffer" "undo-tree-visualizer-selection-mode" "vdiff-hydra/vdiff-close-other-folds" "calendar-mayan-previous-tzolkin-date" "clojure-convert-collection-to-vector" "color-theme-sanityinc-tomorrow-night" "delete-file-local-variable-prop-line" "evil-ex-repeat-substitute-with-flags" "evil-multiedit-match-symbol-and-next" "evil-multiedit-match-symbol-and-prev" "evil-visualstar/begin-search-forward" "feedmail-run-the-queue-global-prompt" "file-cache-add-directory-recursively" "haskell-interactive-mode-reset-error" "haskell-interactive-mode-visit-error" "ibuffer-mark-compressed-file-buffers" "ido-find-alternate-file-other-window" "ido-find-file-read-only-other-window" "kmacro-start-macro-or-insert-counter" "magit-jump-to-unpulled-from-upstream" "magit-jump-to-unpushed-to-pushremote" "magit-worktree-checkout-pull-request" "markdown-outline-previous-same-level" "markdown-unfontify-region-wiki-links" "minibuffer-insert-file-name-at-point" "nonincremental-repeat-search-forward" "org-blackfriday-convert-region-to-md" "org-footnote-goto-previous-reference" "org-table-toggle-coordinate-overlays" "orgtbl-create-or-convert-from-region" "outshine-agenda-set-restriction-lock" "outshine-toggle-hidden-lines-cookies" "projectile-reset-cached-project-name" "projectile-reset-cached-project-root" "projectile-run-shell-command-in-root" "scroll-bar-toolkit-horizontal-scroll" "setup-specified-language-environment" "turn-on-haskell-unicode-input-method" "undo-tree-visualizer-select-previous" "vc-default-revision-completion-table" "vdiff-toggle-hydra/vdiff-toggle-case" "color-theme-sanityinc-tomorrow-bright" "comint-dynamic-list-input-ring-select" "comint-next-matching-input-from-input" "ediff-merge-directories-with-ancestor" "ediff-toggle-verbose-help-meta-buffer" "eudc-insert-record-at-point-into-bbdb" "evgeni-hydra-zoom/text-scale-decrease" "evil-collection-ediff-last-difference" "evil-ex-repeat-substitute-with-search" "evil-ex-search-unbounded-word-forward" "evil-visualstar/begin-search-backward" "ff-mouse-find-other-file-other-window" "file-cache-add-directory-using-locate" "follow-delete-other-windows-and-split" "git-commit-insert-issue-gitlab-insert" "gnus-article-outlook-deuglify-article" "ibuffer-do-shell-command-pipe-replace" "ibuffer-switch-to-saved-filter-groups" "isearch-toggle-specified-input-method" "message-cross-post-followup-to-header" "minibuffer-default-add-shell-commands" "nonincremental-repeat-search-backward" "org-babel-switch-to-session-with-code" "org-capture-import-remember-templates" "org-src-do-key-sequence-at-code-block" "org-texinfo-convert-region-to-texinfo" "outorg-insert-default-export-template" "projectile-find-file-dwim-other-frame" "undo-tree-restore-state-from-register" "which-key-show-previous-page-no-cycle" "bookmark-bmenu-other-window-with-mouse" "comint-history-isearch-backward-regexp" "delete-selection-repeat-replace-region" "describe-current-coding-system-briefly" "diary-chinese-insert-anniversary-entry" "ediff-show-current-session-meta-buffer" "evgeni-magit-diff-unstaged-buffer-file" "evil-collection-ediff-first-difference" "evil-ex-search-unbounded-word-backward" "image-dired-dired-toggle-marked-thumbs" "isearch-nonincremental-exit-minibuffer" "magit-blame-previous-chunk-same-commit" "magit-find-git-config-file-other-frame" "magit-jump-to-unpulled-from-pushremote" "markdown-live-preview-switch-to-output" "menu-bar-showhide-fringe-ind-customize" "outshine-TeX-command-region-on-subtree" "outshine-toggle-subtree-comment-status" "projectile-find-file-dwim-other-window" "projectile-find-file-in-known-projects" "projectile-find-other-file-other-frame" "undo-tree-visualize-switch-branch-left" "undo-tree-visualizer-toggle-timestamps" "uniquify-rationalize-file-buffer-names" "calendar-mouse-view-other-diary-entries" "color-theme-sanityinc-tomorrow-eighties" "comint-redirect-send-command-to-process" "gnus-article-outlook-repair-attribution" "hydra-goto-last-change/goto-last-change" "image-dired-dired-edit-comment-and-tags" "magit-add-change-log-entry-other-window" "magit-find-git-config-file-other-window" "magit-popup-toggle-show-common-commands" "menu-bar-showhide-fringe-menu-customize" "occur-mode-goto-occurrence-other-window" "org-insert-todo-heading-respect-content" "org-table-create-or-convert-from-region" "org-toggle-custom-properties-visibility" "outshine-agenda-remove-restriction-lock" "outshine-latex-insert-headers-in-buffer" "package-menu-mark-obsolete-for-deletion" "projectile-find-other-file-other-window" "projectile-project-buffers-other-buffer" "projectile-switch-to-buffer-other-frame" "undo-tree-visualize-switch-branch-right" "vdiff-hydra/vdiff-send-changes-and-step" "Electric-command-history-redo-expression" "comint-dynamic-list-filename-completions" "copy-dir-locals-to-file-locals-prop-line" "diff-add-change-log-entries-other-window" "ebrowse-tags-find-definition-other-frame" "ebrowse-tags-view-definition-other-frame" "elisp-flymake--batch-compile-for-flymake" "evil-beginning-of-line-or-digit-argument" "evil-multiedit-toggle-or-restrict-region" "flyspell-check-previous-highlighted-word" "menu-bar-bottom-and-right-window-divider" "org-babel-do-key-sequence-in-edit-buffer" "org-set-visibility-according-to-property" "projectile-switch-to-buffer-other-window" "which-key-setup-side-window-right-bottom" "clojure-convert-collection-to-quoted-list" "comint-previous-matching-input-from-input" "ebrowse-tags-find-declaration-other-frame" "ebrowse-tags-find-definition-other-window" "ebrowse-tags-view-definition-other-window" "ediff-revert-buffers-then-recompute-diffs" "evil-collection-diff-toggle-restrict-view" "outorg-replace-source-blocks-with-results" "outshine-agenda-toggle-include-org-agenda" "projectile-discover-projects-in-directory" "ebrowse-tags-find-declaration-other-window" "ibuffer-visit-buffer-other-window-noselect" "message-insert-disposition-notification-to" "message-make-html-message-with-image-files" "outorg-edit-comments-and-propagate-changes" "pkg-info-defining-library-original-version" "projectile-run-async-shell-command-in-root" "type-break-guesstimate-keystroke-threshold" "undo-tree-visualizer-selection-toggle-diff" "vdiff-hydra/vdiff-receive-changes-and-step" "vdiff-toggle-hydra/vdiff-toggle-whitespace" "dired-sidebar-toggle-with-current-directory" "evgeni-insert-ticket-number-from-git-branch" "evil-collection-diff-toggle-context-unified" "image-dired-dired-with-window-configuration" "log-edit-insert-filenames-without-changelog" "restclient-http-send-current-stay-in-window" "shell-dynamic-complete-environment-variable" "evgeni-toggles-hydra/auto-fill-mode-and-exit" "markdown-toggle-fontify-code-blocks-natively" "menu-bar-showhide-fringe-menu-customize-left" "vdiff-hydra/vdiff-remove-refinements-in-hunk" "vdiff-hydra/vdiff-toggle-hydra/body-and-exit" "vdiff-toggle-hydra/vdiff-hydra/body-and-exit" "ediff-merge-directory-revisions-with-ancestor" "evil-digit-argument-or-evil-beginning-of-line" "menu-bar-showhide-fringe-menu-customize-reset" "menu-bar-showhide-fringe-menu-customize-right" "org-archive-subtree-default-with-confirmation" "rmail-speedbar-move-message-to-folder-on-line" "evgeni-toggles-hydra/visual-line-mode-and-exit" "message-generate-unsubscribed-mail-followup-to" "evil-commentary/org-comment-or-uncomment-region" "evil-ex-repeat-substitute-with-search-and-flags" "menu-bar-showhide-fringe-menu-customize-disable" "outshine-toggle-hidden-lines-cookies-activation" "evil-collection-buff-menu-Buffer-menu-unmark-all" "evgeni-toggles-hydra/global-hl-line-mode-and-exit" "evgeni-toggles-hydra/toggle-input-method-and-exit" "evil-digit-argument-or-evil-org-beginning-of-line" "evil-org-org-insert-heading-respect-content-below" "menu-bar-showhide-tool-bar-menu-customize-disable" "moody-replace-sml/mode-line-buffer-identification" "projectile-toggle-between-implementation-and-test" "projectile-find-implementation-or-test-other-frame" "evgeni-toggles-hydra/linum-relative-toggle-and-exit" "projectile-find-implementation-or-test-other-window" "menu-bar-showhide-tool-bar-menu-customize-enable-top" "menu-bar-showhide-tool-bar-menu-customize-enable-left" "projectile-remove-current-project-from-known-projects" "evil-org-org-insert-todo-heading-respect-content-below" "menu-bar-showhide-tool-bar-menu-customize-enable-right" "evgeni-toggles-hydra/display-line-numbers-mode-and-exit" "menu-bar-showhide-tool-bar-menu-customize-enable-bottom" "evil-collection-buff-menu-Buffer-menu-unmark-all-buffers" "company-select-next-if-tooltip-visible-or-complete-selection" "evil-collection-elisp-mode-return-or-last-sexp-toggle-display") :predicate nil :require-match t :history counsel-M-x-history :action #f(compiled-function (cmd) #<bytecode 0x44107281>) :sort nil :keymap (keymap (29 . counsel-find-symbol) (67108908 . counsel--info-lookup-symbol) (67108910 . counsel-find-symbol)) :initial-input nil :caller counsel-M-x)
  counsel-M-x()
  funcall-interactively(counsel-M-x)
  call-interactively(counsel-M-x nil nil)
  command-execute(counsel-M-x)
```

I'm not sure if there's a benefit from using `magit-completing-read` over `completing-read`. Using the latter fixes the issue for me. I use ivy-mode, by the way, which could be causing this error.