### PR TITLE
magit-modified-files was renamed to magit-unstaged-files

### DIFF
--- a/vdiff-magit.el
+++ b/vdiff-magit.el
@@ -317,7 +317,7 @@ and discard changes using vdiff, use `vdiff-magit-stage'.
 FILE must be relative to the top directory of the repository."
   (interactive
    (list (magit-read-file-choice "Show unstaged changes for file"
-                                 (magit-modified-files)
+                                 (magit-unstaged-files)
                                  "No unstaged files")))
   (magit-with-toplevel
     (vdiff-buffers


### PR DESCRIPTION
It was renamed and marked deprecated in https://github.com/magit/magit/commit/e55874f0aa3ba3cd228e7ff8d04d7733633be99c (Magit 2.11.0), and removed entirely in https://github.com/magit/magit/commit/aba4bdaf95ce944bb37c6851b5005941c9d15842, so vdiff-magit will break when the next stable release of magit happens.  This is safe to merge now since the new function name does exist in the current stable magit.