### PR TITLE
kill only temp buffers in vdiff-magit-compare

### DIFF
--- a/vdiff-magit.el
+++ b/vdiff-magit.el
@@ -184,6 +184,21 @@ FILE has to be relative to the top directory of the repository."
               (kill-buffer buf-a)))
          t nil)))))
 
+(defun vdiff-magit--kill-buffer-if-temporary (buffer)
+  "Kills `buffer' if it does not point to a file on disk."
+  (when (let ((buf-file (buffer-file-name buffer)))
+          (or (not buf-file) (not (file-exists-p buf-file))))
+    (kill-buffer buffer)))
+
+(defun vdiff-magit--kill-temp-buffers (b1 b2)
+  "Kill b1 and or b2 if they are temporary buffers
+
+This is expected to be used as a callback to vdiff-buffers so
+that, for example, in `vdiff-magit-compare`, we preseve the
+original file buffer."
+  (vdiff-magit--kill-buffer-if-temporary b1)
+  (vdiff-magit--kill-buffer-if-temporary b2))
+
 ;; ;;;###autoload
 (defun vdiff-magit-compare (rev-a rev-b file-a file-b)
   "Compare REVA:FILEA with REVB:FILEB using vdiff.
@@ -213,7 +228,7 @@ range)."
              (magit-find-file-noselect rev-b file-b))
        (or (get-file-buffer file-b)
            (find-file-noselect file-b)))
-     nil nil t t)))
+     nil 'vdiff-magit--kill-temp-buffers t nil)))
 
 ;;;###autoload
 (defun vdiff-magit-dwim ()


### PR DESCRIPTION
Instead of just killing both buffers when vdiff-buffers
finishes (KILL-BUFFERS-ON-QUIT=t), preserve any buffers that are
pointing to files.

This is predicated on the assumption that most times, e.g. `M-x
vdiff-magit-compare` is running against an open file, comparing it to
a revision, and then that the user would like to preserve the original
file buffer they were using before starting vdiff.